### PR TITLE
Scaffold FastAPI app

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,16 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/")
+async def root() -> dict[str, str]:
+    """Basic health check endpoint."""
+    return {"status": "ok"}
+
+# Placeholder: include routers from app/api when available
+try:
+    from app.api import router as api_router  # type: ignore
+    app.include_router(api_router)
+except Exception:
+    pass

--- a/run_local.sh
+++ b/run_local.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Run the FastAPI app locally with autoreload.
+PORT=${PORT:-8000}
+exec uvicorn app.main:app --reload --host 0.0.0.0 --port "$PORT"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_root():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- create FastAPI main module and health check
- add script to run the service locally
- provide placeholder for future API routers
- add basic test for `/` endpoint

## Testing
- `pip install -r requirements.txt` *(fails: Could not find 'playwright')*
- `pytest -q` *(fails: ModuleNotFoundError: httpx)*

------
https://chatgpt.com/codex/tasks/task_e_684a22d2c85483269074a1647c301399