### PR TITLE
Implement Redis session storage utility

### DIFF
--- a/app/storage/redis.py
+++ b/app/storage/redis.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import os
+from dotenv import load_dotenv
+import redis
+
+load_dotenv()
+
+REDIS_HOST = os.getenv("REDIS_HOST", "localhost")
+REDIS_PORT = int(os.getenv("REDIS_PORT", "6379"))
+REDIS_PASSWORD = os.getenv("REDIS_PASSWORD")
+
+_redis_client = redis.Redis(
+    host=REDIS_HOST,
+    port=REDIS_PORT,
+    password=REDIS_PASSWORD,
+    decode_responses=True,
+)
+
+
+def set_key(key: str, value: str, expire: int | None = None) -> bool:
+    """Set ``key`` to ``value`` with optional expiration in seconds."""
+    return bool(_redis_client.set(name=key, value=value, ex=expire))
+
+
+def get_key(key: str) -> str | None:
+    """Retrieve the value for ``key`` if present."""
+    return _redis_client.get(name=key)
+
+
+def delete_key(key: str) -> int:
+    """Delete ``key`` from Redis, returning the number of keys removed."""
+    return _redis_client.delete(key)
+
+
+def is_connected() -> bool:
+    """Check if the Redis client can connect."""
+    try:
+        return _redis_client.ping()
+    except redis.RedisError:
+        return False
+
+
+if __name__ == "__main__":
+    example_key = "demo"
+    set_key(example_key, "hello world", expire=60)
+    print("Value:", get_key(example_key))
+    delete_key(example_key)
+    print("After delete:", get_key(example_key))

--- a/tests/test_redis_storage.py
+++ b/tests/test_redis_storage.py
@@ -1,0 +1,46 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+class FakeRedis:
+    def __init__(self, *args, **kwargs):
+        self.store = {}
+
+    def set(self, name, value, ex=None):
+        self.store[name] = value
+        return True
+
+    def get(self, name):
+        return self.store.get(name)
+
+    def delete(self, name):
+        return 1 if self.store.pop(name, None) is not None else 0
+
+    def ping(self):
+        return True
+
+
+def test_set_get_delete(monkeypatch):
+    fake_module = types.SimpleNamespace(Redis=FakeRedis, RedisError=Exception)
+    monkeypatch.setitem(sys.modules, "redis", fake_module)
+    monkeypatch.setitem(sys.modules, "dotenv", types.SimpleNamespace(load_dotenv=lambda: None))
+    monkeypatch.setenv("REDIS_HOST", "localhost")
+    monkeypatch.setenv("REDIS_PORT", "6379")
+    monkeypatch.delenv("REDIS_PASSWORD", raising=False)
+    module = importlib.import_module("app.storage.redis")
+    importlib.reload(module)
+
+    assert module.is_connected()
+
+    module.set_key("foo", "bar")
+    assert module.get_key("foo") == "bar"
+    assert module.delete_key("foo") == 1
+    assert module.get_key("foo") is None
+
+


### PR DESCRIPTION
## Summary
- add storage package with Redis helper
- write unit tests for Redis helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a23389cb08326bea26ce06819eb73