### PR TITLE
Add lab PDF parser

### DIFF
--- a/app/processors/lab_pdf_parser.py
+++ b/app/processors/lab_pdf_parser.py
@@ -1,0 +1,69 @@
+"""Lab PDF parser to extract structured lab results."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import List, Dict, Optional
+
+import fitz  # PyMuPDF
+
+
+DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}")
+
+
+def extract_lab_results_with_date(pdf_path: str | Path) -> List[Dict[str, Optional[str]]]:
+    """Parse lab results from ``pdf_path`` and include dates when available.
+
+    Parameters
+    ----------
+    pdf_path: str | Path
+        The path to the PDF file containing lab results.
+
+    Returns
+    -------
+    List[Dict[str, Optional[str]]]
+        List of dictionaries with ``test_name``, ``value``, ``units`` and
+        optional ``date`` field.
+    """
+
+    path = Path(pdf_path)
+    if not path.exists():
+        raise FileNotFoundError(f"PDF not found: {pdf_path}")
+
+    results: List[Dict[str, Optional[str]]] = []
+
+    text = ""
+    with fitz.open(path) as doc:
+        for page in doc:
+            text += page.get_text("text")
+
+    for line in text.splitlines():
+        parts = line.strip().split()
+        if len(parts) < 3:
+            continue
+
+        date: Optional[str] = None
+        # Check for date pattern in last token
+        if DATE_RE.fullmatch(parts[-1]):
+            date = parts[-1]
+            units = parts[-2]
+            value = parts[-3]
+            name_tokens = parts[:-3]
+        else:
+            units = parts[-1]
+            value = parts[-2]
+            name_tokens = parts[:-2]
+
+        if not value.replace('.', '', 1).isdigit():
+            continue
+
+        test_name = " ".join(name_tokens)
+        results.append({
+            "test_name": test_name,
+            "value": value,
+            "units": units,
+            "date": date,
+        })
+
+    return results

--- a/tests/test_lab_pdf_parser.py
+++ b/tests/test_lab_pdf_parser.py
@@ -1,0 +1,30 @@
+import os
+from pathlib import Path
+import fitz
+from app.processors.lab_pdf_parser import extract_lab_results_with_date
+
+
+def create_sample_pdf(tmp_path: Path) -> Path:
+    """Create a small PDF with two lab results."""
+    file_path = tmp_path / "sample.pdf"
+    doc = fitz.open()
+    page = doc.new_page()
+    # line with date
+    page.insert_text((72, 72), "Cholesterol 5.8 mmol/L 2023-05-01")
+    # second line without date
+    page.insert_text((72, 90), "Hemoglobin 13.5 g/dL")
+    doc.save(file_path)
+    doc.close()
+    return file_path
+
+
+def test_extract_lab_results_with_date(tmp_path):
+    pdf = create_sample_pdf(tmp_path)
+    results = extract_lab_results_with_date(pdf)
+    assert len(results) == 2
+    assert results[0]["test_name"] == "Cholesterol"
+    assert results[0]["value"] == "5.8"
+    assert results[0]["units"] == "mmol/L"
+    assert results[0]["date"] == "2023-05-01"
+    assert results[1]["test_name"] == "Hemoglobin"
+    assert results[1]["date"] is None


### PR DESCRIPTION
## Summary
- add PDF parser supporting optional dates
- test parser with generated sample PDF

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a2ef28fc48326a851af98ad99a6e6