### PR TITLE
Add visit summary HTML parser

### DIFF
--- a/app/processors/visit_html_parser.py
+++ b/app/processors/visit_html_parser.py
@@ -1,0 +1,42 @@
+"""HTML parser for extracting visit summaries."""
+
+from __future__ import annotations
+
+from typing import List, Dict
+
+from bs4 import BeautifulSoup
+
+
+def extract_visit_summaries(html: str) -> List[Dict[str, str]]:
+    """Parse ``html`` and return visit summaries.
+
+    Parameters
+    ----------
+    html: str
+        HTML content containing visit summary entries.
+
+    Returns
+    -------
+    List[Dict[str, str]]
+        Each dict contains ``date``, ``provider``, ``doctor`` and ``notes``.
+    """
+
+    soup = BeautifulSoup(html, "html.parser")
+    visits: List[Dict[str, str]] = []
+
+    for section in soup.select("div.visit"):
+        date_el = section.select_one(".date")
+        provider_el = section.select_one(".provider")
+        doctor_el = section.select_one(".doctor")
+        notes_el = section.select_one(".notes")
+
+        visits.append(
+            {
+                "date": date_el.get_text(strip=True) if date_el else "",
+                "provider": provider_el.get_text(strip=True) if provider_el else "",
+                "doctor": doctor_el.get_text(strip=True) if doctor_el else "",
+                "notes": notes_el.get_text(strip=True) if notes_el else "",
+            }
+        )
+
+    return visits

--- a/tests/test_visit_html_parser.py
+++ b/tests/test_visit_html_parser.py
@@ -1,0 +1,38 @@
+from app.processors.visit_html_parser import extract_visit_summaries
+
+
+def test_extract_visit_summaries():
+    html = """
+    <html>
+      <body>
+        <div class='visit'>
+          <span class='date'>2023-06-01</span>
+          <span class='provider'>General Hospital</span>
+          <span class='doctor'>Dr. Jones</span>
+          <p class='notes'>Follow-up recommended.</p>
+        </div>
+        <div class='visit'>
+          <span class='date'>2023-07-10</span>
+          <span class='provider'>City Clinic</span>
+          <span class='doctor'>Dr. Smith</span>
+          <p class='notes'>All good.</p>
+        </div>
+      </body>
+    </html>
+    """
+    expected = [
+        {
+            "date": "2023-06-01",
+            "provider": "General Hospital",
+            "doctor": "Dr. Jones",
+            "notes": "Follow-up recommended.",
+        },
+        {
+            "date": "2023-07-10",
+            "provider": "City Clinic",
+            "doctor": "Dr. Smith",
+            "notes": "All good.",
+        },
+    ]
+
+    assert extract_visit_summaries(html) == expected


### PR DESCRIPTION
## Summary
- implement `extract_visit_summaries` for parsing visit summaries from HTML
- add unit test covering typical HTML layout

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a2f1216e083269a3e6ef9090df3e7