### PR TITLE
Add structuring DB insert helpers

### DIFF
--- a/app/processors/structuring.py
+++ b/app/processors/structuring.py
@@ -1,0 +1,52 @@
+"""Utilities for inserting structured data into the database."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import List, Dict
+
+from sqlalchemy.orm import Session
+
+from app.storage.models import LabResult, VisitSummary
+
+
+def _parse_date(value: str | date) -> date:
+    """Convert an ISO date string or ``date`` into ``date``."""
+    if isinstance(value, date):
+        return value
+    return date.fromisoformat(value)
+
+
+def insert_lab_results(session: Session, results: List[Dict]):
+    """Convert ``results`` to ``LabResult`` objects and save them."""
+    objects = []
+    for entry in results:
+        if not entry.get("date"):
+            # Skip entries without a valid date since column is non-nullable
+            continue
+        lab = LabResult(
+            test_name=entry["test_name"],
+            value=float(entry["value"]),
+            units=entry["units"],
+            date=_parse_date(entry["date"]),
+        )
+        objects.append(lab)
+    session.add_all(objects)
+    session.commit()
+
+
+def insert_visit_summaries(session: Session, summaries: List[Dict]):
+    """Convert ``summaries`` to ``VisitSummary`` objects and save them."""
+    objects = []
+    for entry in summaries:
+        if not entry.get("date"):
+            continue
+        visit = VisitSummary(
+            provider=entry["provider"],
+            doctor=entry["doctor"],
+            notes=entry["notes"],
+            date=_parse_date(entry["date"]),
+        )
+        objects.append(visit)
+    session.add_all(objects)
+    session.commit()

--- a/tests/test_structuring.py
+++ b/tests/test_structuring.py
@@ -1,0 +1,41 @@
+import os
+import importlib
+
+from app.processors.structuring import insert_lab_results, insert_visit_summaries
+
+
+def test_insert_functions():
+    os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+    import app.storage.db as db_module
+    import app.storage.models as models_module
+    db_module = importlib.reload(db_module)
+    models = importlib.reload(models_module)
+
+    db_module.init_db()
+    session = db_module.SessionLocal()
+
+    lab_data = [
+        {"test_name": "Cholesterol", "value": "5.8", "units": "mmol/L", "date": "2023-05-01"},
+        {"test_name": "Hemoglobin", "value": "13.5", "units": "g/dL", "date": "2023-05-02"},
+    ]
+    insert_lab_results(session, lab_data)
+
+    visit_data = [
+        {"date": "2023-06-01", "provider": "General Hospital", "doctor": "Dr. Jones", "notes": "Follow-up"},
+        {"date": "2023-07-10", "provider": "City Clinic", "doctor": "Dr. Smith", "notes": "All good."},
+    ]
+    insert_visit_summaries(session, visit_data)
+
+    labs = session.query(models.LabResult).order_by(models.LabResult.id).all()
+    visits = session.query(models.VisitSummary).order_by(models.VisitSummary.id).all()
+
+    assert len(labs) == 2
+    assert labs[0].test_name == "Cholesterol"
+    assert labs[0].value == 5.8
+    assert labs[1].units == "g/dL"
+
+    assert len(visits) == 2
+    assert visits[0].provider == "General Hospital"
+    assert visits[1].notes == "All good."
+
+    session.close()


### PR DESCRIPTION
## Summary
- add utilities to insert parsed data into the DB
- unit test for structuring insert functions using in-memory SQLite
- install compatible httpx version for tests

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a3109f0248326a259ea6198570fb1