### PR TITLE
Add lab results summarizer

### DIFF
--- a/app/prompts/summarizer.py
+++ b/app/prompts/summarizer.py
@@ -1,0 +1,21 @@
+import openai
+from typing import List, Dict
+
+from .loader import load_prompt
+
+
+def summarize_lab_results(results: List[Dict]) -> str:
+    """Return a summary of lab results using an OpenAI model.
+
+    Parameters
+    ----------
+    results: List[Dict]
+        Each dict represents a lab result with keys like ``test_name``,
+        ``value``, ``units``, and ``date``.
+    """
+    prompt = load_prompt("summarize_lab_results", {"lab_data": results})
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return response["choices"][0]["message"]["content"].strip()

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -1,0 +1,19 @@
+import openai
+import types
+from app.prompts.summarizer import summarize_lab_results
+
+
+def test_summarize_lab_results(monkeypatch):
+    # Prepare fake response
+    def fake_create(*args, **kwargs):
+        return {"choices": [{"message": {"content": "Summary text"}}]}
+
+    monkeypatch.setattr(openai.ChatCompletion, "create", fake_create)
+
+    labs = [
+        {"test_name": "Cholesterol", "value": 5.8, "units": "mmol/L", "date": "2023-05-01"},
+        {"test_name": "Hemoglobin", "value": 13.5, "units": "g/dL", "date": "2023-05-02"},
+    ]
+
+    summary = summarize_lab_results(labs)
+    assert summary == "Summary text"


### PR DESCRIPTION
## Summary
- implement summarize_lab_results using OpenAI chat completion
- add unit tests mocking OpenAI response

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a33e63c4483269e8ccd21c3eab53e