### PR TITLE
Implement RAG API endpoint

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,0 +1,6 @@
+from fastapi import APIRouter
+
+from .rag import router as rag_router
+
+router = APIRouter()
+router.include_router(rag_router)

--- a/app/api/rag.py
+++ b/app/api/rag.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+import openai
+
+
+
+router = APIRouter()
+
+
+class QueryRequest(BaseModel):
+    query: str
+
+
+@router.post("/ask")
+def ask_question(payload: QueryRequest) -> dict[str, str]:
+    """Answer a health question using recent labs and visit notes as context."""
+    from app.storage.db import SessionLocal
+    from app.storage import models
+
+    session = SessionLocal()
+    try:
+        labs = (
+            session.query(models.LabResult)
+            .order_by(models.LabResult.date.desc())
+            .limit(5)
+            .all()
+        )
+        visits = (
+            session.query(models.VisitSummary)
+            .order_by(models.VisitSummary.date.desc())
+            .limit(5)
+            .all()
+        )
+    finally:
+        session.close()
+
+    lab_lines = [
+        f"- {lab.test_name}: {lab.value} {lab.units} ({lab.date})" for lab in labs
+    ]
+    visit_lines = [
+        f"- {v.date} - {v.provider} - {v.doctor}: {v.notes}" for v in visits
+    ]
+
+    context = "Recent Lab Results:\n" + "\n".join(lab_lines)
+    context += "\n\nRecent Visits:\n" + "\n".join(visit_lines)
+
+    prompt = f"{context}\n\nQuestion: {payload.query}"
+
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    answer = response["choices"][0]["message"]["content"].strip()
+    return {"answer": answer}

--- a/tests/test_rag_api.py
+++ b/tests/test_rag_api.py
@@ -1,0 +1,68 @@
+import os
+import importlib
+from datetime import date
+import tempfile
+
+import openai
+from fastapi.testclient import TestClient
+
+
+def setup_app(labs, visits, monkeypatch):
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    tmp.close()
+    os.environ["DATABASE_URL"] = f"sqlite:///{tmp.name}"
+    # Reload db and models to use new DB URL
+    import app.storage.db as db_module
+    import app.storage.models as models_module
+    db_module = importlib.reload(db_module)
+    models_module = importlib.reload(models_module)
+    db_module.init_db()
+
+    session = db_module.SessionLocal()
+    for lab in labs:
+        session.add(models_module.LabResult(**lab))
+    for visit in visits:
+        session.add(models_module.VisitSummary(**visit))
+    session.commit()
+    session.close()
+
+    def fake_create(*args, **kwargs):
+        content = kwargs["messages"][0]["content"]
+        # Ensure context is included
+        for lab in labs:
+            assert lab["test_name"] in content
+        for visit in visits:
+            assert visit["provider"] in content
+        return {"choices": [{"message": {"content": "Mock answer"}}]}
+
+    monkeypatch.setattr(openai.ChatCompletion, "create", fake_create)
+
+    import app.main as main_module
+    main_module = importlib.reload(main_module)
+    return TestClient(main_module.app), tmp.name
+
+
+def test_ask_endpoint(monkeypatch):
+    labs = [
+        {
+            "test_name": "Cholesterol",
+            "value": 5.8,
+            "units": "mmol/L",
+            "date": date.fromisoformat("2023-05-01"),
+        }
+    ]
+    visits = [
+        {
+            "date": date.fromisoformat("2023-06-01"),
+            "provider": "General Hospital",
+            "doctor": "Dr. Jones",
+            "notes": "Routine check",
+        }
+    ]
+
+    client, path = setup_app(labs, visits, monkeypatch)
+    resp = client.post("/ask", json={"query": "How am I doing?"})
+    assert resp.status_code == 200
+    assert resp.json() == {"answer": "Mock answer"}
+    os.unlink(path)
+


### PR DESCRIPTION
## Summary
- add `/ask` POST endpoint using RAG to answer questions
- wire new endpoint into API router
- create tests for RAG API

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a3562881c83268e4ebc7504576ccd