### PR TITLE
Implement ETL orchestrator with tests

### DIFF
--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -1,0 +1,89 @@
+import os
+import asyncio
+import importlib
+from pathlib import Path
+
+from app.storage.files import save_file
+from app.storage.db import init_db, SessionLocal
+from app.processors.lab_pdf_parser import extract_lab_results_with_date
+from app.processors.visit_html_parser import extract_visit_summaries
+from app.processors.structuring import insert_lab_results, insert_visit_summaries
+
+
+def _load_scraper(portal_name: str):
+    module = importlib.import_module(f"app.adapters.{portal_name}")
+    func_name = f"scrape_{portal_name}"
+    scraper = getattr(module, func_name, None)
+    if scraper is None:
+        raise AttributeError(f"Scraper function '{func_name}' not found")
+    return scraper
+
+
+def _run_scraper(scraper, portal_name: str):
+    username = os.getenv(f"{portal_name.upper()}_USERNAME")
+    password = os.getenv(f"{portal_name.upper()}_PASSWORD")
+    url = os.getenv(f"{portal_name.upper()}_URL")
+    args = []
+    if username:
+        args.append(username)
+    if password:
+        args.append(password)
+    if url:
+        args.append(url)
+    if asyncio.iscoroutinefunction(scraper):
+        return asyncio.run(scraper(*args))
+    return scraper(*args)
+
+
+def _extract_file_paths(result):
+    if isinstance(result, dict) and "files" in result:
+        files = result["files"]
+    else:
+        files = result
+    paths = []
+    for item in files:
+        if isinstance(item, dict) and "file_path" in item:
+            paths.append(item["file_path"])
+        else:
+            paths.append(str(item))
+    return paths
+
+
+def run_etl_for_portal(portal_name: str) -> None:
+    """Run scraping, parsing and DB insertion for ``portal_name``."""
+    print(f"[etl] Starting pipeline for {portal_name}")
+    scraper = _load_scraper(portal_name)
+    print(f"[etl] Running scraper {scraper.__name__}")
+    result = _run_scraper(scraper, portal_name)
+    file_paths = _extract_file_paths(result)
+    print(f"[etl] {len(file_paths)} files scraped")
+
+    init_db()
+    session = SessionLocal()
+    labs_all = []
+    visits_all = []
+    try:
+        for path_str in file_paths:
+            path = Path(path_str)
+            if not path.exists():
+                continue
+            content = path.read_bytes()
+            save_file(content, path.name, portal_name, {"source": path_str})
+            if path.suffix.lower() == ".pdf":
+                print(f"[etl] Parsing labs from {path_str}")
+                labs = extract_lab_results_with_date(path_str)
+                labs_all.extend(labs)
+            else:
+                print(f"[etl] Parsing visits from {path_str}")
+                html = content.decode("utf-8", errors="ignore")
+                visits = extract_visit_summaries(html)
+                visits_all.extend(visits)
+        if labs_all:
+            print(f"[etl] Inserting {len(labs_all)} lab results")
+            insert_lab_results(session, labs_all)
+        if visits_all:
+            print(f"[etl] Inserting {len(visits_all)} visit summaries")
+            insert_visit_summaries(session, visits_all)
+    finally:
+        session.close()
+        print(f"[etl] Pipeline for {portal_name} complete")

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,50 @@
+import os
+def test_run_etl_for_portal(monkeypatch, tmp_path, capsys):
+    os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+    os.environ["PORTAL_A_USERNAME"] = "user"
+    os.environ["PORTAL_A_PASSWORD"] = "pass"
+
+    html_file = tmp_path / "dash.html"
+    html_file.write_text("<div class='visit'><span class='date'>2023-01-01</span><span class='provider'>Clinic</span><span class='doctor'>Dr. X</span><p class='notes'>Hi</p></div>")
+    pdf_file = tmp_path / "lab.pdf"
+    pdf_file.write_bytes(b"%PDF-1.4")
+
+    # Mock scraper
+    def fake_scraper(username, password):
+        assert username == "user"
+        assert password == "pass"
+        return {"files": [str(html_file), str(pdf_file)]}
+
+    import app.adapters.portal_a as portal_module
+    monkeypatch.setattr(portal_module, "scrape_portal_a", fake_scraper)
+
+    # Mock parsers
+    visits = [{"date": "2023-01-01", "provider": "Clinic", "doctor": "Dr. X", "notes": "Hi"}]
+    labs = [{"test_name": "A", "value": "1", "units": "mg", "date": "2023-01-02"}]
+
+    import app.processors.visit_html_parser as vh_parser
+    import app.processors.lab_pdf_parser as lab_parser
+    monkeypatch.setattr(vh_parser, "extract_visit_summaries", lambda html: visits)
+    monkeypatch.setattr(lab_parser, "extract_lab_results_with_date", lambda path: labs)
+
+    inserted = {"labs": None, "visits": None}
+    import app.processors.structuring as struct_module
+
+    def fake_insert_labs(session, results):
+        inserted["labs"] = results
+
+    def fake_insert_visits(session, results):
+        inserted["visits"] = results
+
+    monkeypatch.setattr(struct_module, "insert_lab_results", fake_insert_labs)
+    monkeypatch.setattr(struct_module, "insert_visit_summaries", fake_insert_visits)
+
+    from app.orchestrator import run_etl_for_portal
+    run_etl_for_portal("portal_a")
+
+    assert inserted["labs"] == labs
+    assert inserted["visits"] == visits
+
+    captured = capsys.readouterr()
+    assert "Starting pipeline for portal_a" in captured.out
+    assert "Pipeline for portal_a complete" in captured.out


### PR DESCRIPTION
## Summary
- create `run_etl_for_portal` in `app/orchestrator.py`
- add unit test exercising ETL pipeline logic

## Testing
- `pip install 'httpx==0.24' -q`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a3ad32e348326bb6d34db667695ad