### PR TITLE
Implement credential encryption with Redis

### DIFF
--- a/app/storage/credentials.py
+++ b/app/storage/credentials.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Dict, Optional
+
+from dotenv import load_dotenv
+from cryptography.fernet import Fernet
+
+from . import redis as redis_store
+
+load_dotenv()
+
+FERNET_KEY = os.getenv("FERNET_KEY")
+if not FERNET_KEY:
+    raise ValueError("FERNET_KEY environment variable is required")
+
+_f = Fernet(FERNET_KEY.encode() if isinstance(FERNET_KEY, str) else FERNET_KEY)
+
+PREFIX = "creds"
+TTL_SECONDS = 600  # 10 minutes
+
+
+def _make_key(portal: str) -> str:
+    return f"{PREFIX}:{portal}"
+
+
+def store_credentials(portal: str, username: str, password: str) -> bool:
+    """Encrypt ``password`` and store credentials in Redis with TTL."""
+    data = {
+        "username": username,
+        "password": _f.encrypt(password.encode()).decode(),
+    }
+    return redis_store.set_key(_make_key(portal), json.dumps(data), expire=TTL_SECONDS)
+
+
+def get_credentials(portal: str) -> Optional[Dict[str, str]]:
+    """Retrieve and decrypt credentials for ``portal``."""
+    raw = redis_store.get_key(_make_key(portal))
+    if not raw:
+        return None
+    data = json.loads(raw)
+    password = _f.decrypt(data["password"].encode()).decode()
+    return {"username": data["username"], "password": password}
+
+
+def delete_credentials(portal: str) -> int:
+    """Delete stored credentials for ``portal``."""
+    return redis_store.delete_key(_make_key(portal))

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,8 @@ httpx
 pyyaml
 python-multipart
 aiofiles
+# Optional: encryption
+cryptography
 # Optional: testing + template utilities
 pytest
 jinja2

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,0 +1,42 @@
+import importlib
+import os
+import sys
+import time
+from pathlib import Path
+
+import fakeredis
+from cryptography.fernet import Fernet
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from app.storage import redis as redis_module
+
+
+def _setup(monkeypatch):
+    key = Fernet.generate_key()
+    monkeypatch.setenv("FERNET_KEY", key.decode())
+    redis_module._redis_client = fakeredis.FakeRedis(decode_responses=True)
+    return importlib.reload(importlib.import_module("app.storage.credentials"))
+
+
+def test_encrypt_decrypt_roundtrip(monkeypatch):
+    creds = _setup(monkeypatch)
+
+    creds.store_credentials("portal1", "alice", "secret")
+    raw = redis_module.get_key("creds:portal1")
+    assert raw and "secret" not in raw
+
+    data = creds.get_credentials("portal1")
+    assert data == {"username": "alice", "password": "secret"}
+
+
+def test_ttl_expiry(monkeypatch):
+    creds = _setup(monkeypatch)
+
+    creds.TTL_SECONDS = 1
+    creds.store_credentials("portal2", "bob", "pw")
+    time.sleep(1.1)
+    assert creds.get_credentials("portal2") is None
+
+


### PR DESCRIPTION
## Summary
- add new `credentials.py` with Fernet encryption
- record TTL'd credentials in Redis
- extend requirements with `cryptography`
- add unit tests for round‑trip decryption and TTL expiry

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ad94658d883268298047e8008f3e6