### PR TITLE
Implement consent endpoint and audit logging

### DIFF
--- a/app/api/consent.py
+++ b/app/api/consent.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from datetime import datetime
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from app.storage import audit
+
+router = APIRouter()
+
+
+class ConsentPayload(BaseModel):
+    user_id: str
+    portal_name: str
+    action: str
+    timestamp: datetime
+
+
+@router.post("/consent")
+def record_consent(payload: ConsentPayload) -> dict[str, str]:
+    """Record user consent for portal automation."""
+    audit.log_event(
+        payload.user_id,
+        payload.action,
+        {"portal": payload.portal_name, "timestamp": payload.timestamp.isoformat()},
+    )
+    return {"status": "consent recorded"}

--- a/app/storage/audit.py
+++ b/app/storage/audit.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict
+
+# Location for audit log file can be overridden via AUDIT_LOG env var
+AUDIT_PATH = Path(os.getenv("AUDIT_LOG", "data/audit_log.json"))
+
+
+def log_event(user: str, action: str, context: Dict[str, Any]) -> None:
+    """Append an audit record to ``AUDIT_PATH``.
+
+    Each entry contains ``timestamp``, ``user``, ``action``, and ``context``.
+    ``context`` should be JSON-serialisable.
+    """
+    AUDIT_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+    if AUDIT_PATH.exists():
+        with AUDIT_PATH.open("r", encoding="utf-8") as f:
+            entries = json.load(f)
+    else:
+        entries = []
+
+    entries.append(
+        {
+            "timestamp": datetime.utcnow().isoformat(),
+            "user": user,
+            "action": action,
+            "context": context,
+        }
+    )
+
+    with AUDIT_PATH.open("w", encoding="utf-8") as f:
+        json.dump(entries, f, indent=2)

--- a/tests/test_audit_logging.py
+++ b/tests/test_audit_logging.py
@@ -1,0 +1,48 @@
+import json
+import importlib
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+
+def test_log_event(monkeypatch, tmp_path):
+    log_file = tmp_path / "audit.json"
+    monkeypatch.setenv("AUDIT_LOG", str(log_file))
+    audit = importlib.reload(importlib.import_module("app.storage.audit"))
+
+    audit.log_event("alice", "scrape", {"portal": "portal1"})
+    audit.log_event("bob", "login", {"portal": "portal2"})
+
+    data = json.loads(log_file.read_text())
+    assert len(data) == 2
+    assert data[0]["user"] == "alice"
+    assert data[0]["action"] == "scrape"
+    assert data[0]["context"]["portal"] == "portal1"
+
+
+def test_consent_endpoint(monkeypatch, tmp_path):
+    log_file = tmp_path / "audit.json"
+    monkeypatch.setenv("AUDIT_LOG", str(log_file))
+    audit = importlib.reload(importlib.import_module("app.storage.audit"))
+    consent = importlib.reload(importlib.import_module("app.api.consent"))
+
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    app.include_router(consent.router)
+    client = TestClient(app)
+
+    payload = {
+        "user_id": "user1",
+        "portal_name": "MyChart",
+        "action": "scrape",
+        "timestamp": "2023-01-01T00:00:00",
+    }
+    resp = client.post("/consent", json=payload)
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "consent recorded"}
+
+    logs = json.loads(log_file.read_text())
+    assert len(logs) == 1
+    assert logs[0]["user"] == "user1"
+    assert logs[0]["context"]["portal"] == "MyChart"


### PR DESCRIPTION
## Summary
- add POST /consent endpoint
- add audit logging helper that writes JSON log
- test audit logging and consent flow

## Testing
- `pip install -r requirements.txt`
- `playwright install` *(fails: missing libs)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b0df8d620832692bf4c9fdef219c9