### PR TITLE
Implement LLM HTML extractor

### DIFF
--- a/app/extractor.py
+++ b/app/extractor.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+from typing import List, Dict
+
+import openai
+from bs4 import BeautifulSoup
+
+
+PROMPT_TEMPLATE = (
+    "Extract only patient-relevant content from this page. "
+    "Classify it as one of: lab_result, visit_note, imaging_report, billing_info. "
+    "Return JSON array of objects with keys 'type' and 'text'.\n"
+    "Page content:\n{chunk}"
+)
+
+
+def _clean_html(html: str) -> str:
+    """Return visible text from ``html`` using BeautifulSoup."""
+    soup = BeautifulSoup(html, "html.parser")
+    return soup.get_text(" ", strip=True)
+
+
+def _chunk_text(text: str, max_chars: int) -> List[str]:
+    """Split ``text`` into chunks of ``max_chars`` length."""
+    if max_chars <= 0:
+        return [text]
+    return [text[i : i + max_chars] for i in range(0, len(text), max_chars)]
+
+
+def extract_relevant_content(
+    html: str,
+    source_url: str,
+    *,
+    max_chunk_chars: int = 4000,
+) -> List[Dict[str, str]]:
+    """Extract patient content from ``html`` using an LLM.
+
+    Parameters
+    ----------
+    html:
+        Raw HTML page content.
+    source_url:
+        URL the HTML was fetched from.
+    max_chunk_chars:
+        Maximum characters per LLM prompt chunk.
+    """
+    text = _clean_html(html)
+    chunks = _chunk_text(text, max_chunk_chars)
+    records: List[Dict[str, str]] = []
+
+    for chunk in chunks:
+        prompt = PROMPT_TEMPLATE.format(chunk=chunk)
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": prompt}],
+        )
+        content = response["choices"][0]["message"]["content"]
+        try:
+            entries = json.loads(content)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(entries, dict):
+            entries = [entries]
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            entry["source_url"] = source_url
+            records.append(entry)
+
+    return records

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,45 @@
+import inspect
+import httpx
+from starlette.testclient import TestClient as StarletteTestClient
+from starlette.testclient import _AsyncBackend, _TestClientTransport, _is_asgi3, _WrapASGI2
+
+# Starlette < 0.28 expects httpx.Client to accept 'app' argument. Patch if needed.
+if "app" not in inspect.signature(httpx.Client.__init__).parameters:
+    def _patched_init(
+        self,
+        app,
+        base_url: str = "http://testserver",
+        raise_server_exceptions: bool = True,
+        root_path: str = "",
+        backend: str = "asyncio",
+        backend_options=None,
+        cookies=None,
+        headers=None,
+    ) -> None:
+        self.async_backend = _AsyncBackend(backend=backend, backend_options=backend_options or {})
+        if _is_asgi3(app):
+            asgi_app = app
+        else:
+            asgi_app = _WrapASGI2(app)  # type: ignore[arg-type]
+        self.app = asgi_app
+        self.app_state = {}
+        transport = _TestClientTransport(
+            self.app,
+            portal_factory=self._portal_factory,
+            raise_server_exceptions=raise_server_exceptions,
+            root_path=root_path,
+            app_state=self.app_state,
+        )
+        if headers is None:
+            headers = {}
+        headers.setdefault("user-agent", "testclient")
+        httpx.Client.__init__(
+            self,
+            base_url=base_url,
+            headers=headers,
+            transport=transport,
+            follow_redirects=True,
+            cookies=cookies,
+        )
+
+    StarletteTestClient.__init__ = _patched_init

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -1,0 +1,25 @@
+import openai
+
+from app.extractor import extract_relevant_content
+
+
+def test_extract_relevant_content(monkeypatch):
+    calls = []
+
+    def fake_create(*args, **kwargs):
+        calls.append(kwargs["messages"][0]["content"])
+        return {
+            "choices": [
+                {"message": {"content": '[{"type": "lab_result", "text": "Sodium 140 mmol/L"}]'}}
+            ]
+        }
+
+    monkeypatch.setattr(openai.ChatCompletion, "create", fake_create)
+
+    html = "<html><body><p>Sodium 140 mmol/L</p><p>Another value</p></body></html>"
+    results = extract_relevant_content(html, "https://portal.test/page", max_chunk_chars=20)
+
+    assert len(results) == len(calls)
+    assert all(r["type"] == "lab_result" for r in results)
+    assert results[0]["source_url"] == "https://portal.test/page"
+    assert len(calls) > 1  # ensures chunking occurred


### PR DESCRIPTION
## Summary
- add `extract_relevant_content` to pull patient text from HTML using an LLM
- patch `TestClient` for newer httpx in tests
- test extraction and classification with mocked LLM

## Testing
- `PYTHONPATH=. pytest -q`
- `PYTHONPATH=. pytest -q tests/test_extractor.py`


------
https://chatgpt.com/codex/tasks/task_e_684b1a6a54748326bfdc8ad8dc11c893