### PR TITLE
Generalize summarizer to handle generic blocks

### DIFF
--- a/app/cleaner.py
+++ b/app/cleaner.py
@@ -42,7 +42,7 @@ def clean_blocks(
     *,
     max_chunk_tokens: int = 200,
     summary_token_threshold: int = 1000,
-    summarize: Callable[[List[Dict]], str] = summarizer.summarize_lab_results,
+    summarize: Callable[[List[Dict]], str] = summarizer.summarize_blocks,
 ) -> List[str]:
     """Chunk, deduplicate, and optionally summarize text blocks.
 
@@ -57,7 +57,7 @@ def clean_blocks(
         ``summarize``.
     summarize:
         Function accepting a list of dicts and returning a summary string. By
-        default ``summarizer.summarize_lab_results``.
+        default ``summarizer.summarize_blocks``.
     """
 
     segments: List[str] = []

--- a/app/prompts/summarizer.py
+++ b/app/prompts/summarizer.py
@@ -1,21 +1,33 @@
 import openai
 from typing import List, Dict
 
-from .loader import load_prompt
 
-
-def summarize_lab_results(results: List[Dict]) -> str:
-    """Return a summary of lab results using an OpenAI model.
+def summarize_blocks(blocks: List[Dict[str, str]]) -> str:
+    """Return a natural-language summary of text blocks using OpenAI.
 
     Parameters
     ----------
-    results: List[Dict]
-        Each dict represents a lab result with keys like ``test_name``,
-        ``value``, ``units``, and ``date``.
+    blocks: List[Dict[str, str]]
+        Sequence of dictionaries each containing a ``"text"`` field.
+
+    Returns
+    -------
+    str
+        Concise summary of the provided text.
     """
-    prompt = load_prompt("summarize_lab_results", {"lab_data": results})
+
+    system_prompt = (
+        "Summarize the following content in a way that highlights key details "
+        "clearly. Assume the text may include medical records, summaries, or "
+        "observations. Output a concise, readable summary."
+    )
+
+    combined_text = "\n".join(block.get("text", "") for block in blocks)
     response = openai.ChatCompletion.create(
         model="gpt-3.5-turbo",
-        messages=[{"role": "user", "content": prompt}],
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": combined_text},
+        ],
     )
     return response["choices"][0]["message"]["content"].strip()

--- a/scripts/dev_seed_and_preview.py
+++ b/scripts/dev_seed_and_preview.py
@@ -16,7 +16,7 @@ if str(ROOT_DIR) not in os.sys.path:
 from app.processors.lab_pdf_parser import extract_lab_results_with_date
 from app.processors.visit_html_parser import extract_visit_summaries
 from app.processors.structuring import insert_lab_results, insert_visit_summaries
-from app.prompts.summarizer import summarize_lab_results
+from app.prompts.summarizer import summarize_blocks
 from app.api.rag import ask_question, QueryRequest
 
 
@@ -148,8 +148,8 @@ def main() -> None:
             }
             for l in db_labs
         ]
-        print("\n=== summarize_lab_results() ===")
-        summary = summarize_lab_results(lab_data)
+        print("\n=== summarize_blocks() ===")
+        summary = summarize_blocks([{"text": str(item)} for item in lab_data])
         print(summary)
 
     if args.ask:

--- a/scripts/e2e_test_runner.py
+++ b/scripts/e2e_test_runner.py
@@ -125,7 +125,7 @@ def main() -> None:
 
         openai.ChatCompletion.create = fake_create
 
-        from app.prompts.summarizer import summarize_lab_results
+        from app.prompts.summarizer import summarize_blocks
 
         lab_data = [
             {
@@ -137,8 +137,8 @@ def main() -> None:
             for l in labs
         ]
 
-        print("\n=== STEP 3: summarize_lab_results() ===")
-        summary = summarize_lab_results(lab_data)
+        print("\n=== STEP 3: summarize_blocks() ===")
+        summary = summarize_blocks([{"text": str(item)} for item in lab_data])
         print(summary)
 
         # ------------------------------------------------------------------

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -1,19 +1,18 @@
 import openai
-import types
-from app.prompts.summarizer import summarize_lab_results
+from app.prompts.summarizer import summarize_blocks
 
 
-def test_summarize_lab_results(monkeypatch):
+def test_summarize_blocks(monkeypatch):
     # Prepare fake response
     def fake_create(*args, **kwargs):
         return {"choices": [{"message": {"content": "Summary text"}}]}
 
     monkeypatch.setattr(openai.ChatCompletion, "create", fake_create)
 
-    labs = [
-        {"test_name": "Cholesterol", "value": 5.8, "units": "mmol/L", "date": "2023-05-01"},
-        {"test_name": "Hemoglobin", "value": 13.5, "units": "g/dL", "date": "2023-05-02"},
+    blocks = [
+        {"text": "Patient reports mild headache."},
+        {"text": "Blood pressure within normal range."},
     ]
 
-    summary = summarize_lab_results(labs)
+    summary = summarize_blocks(blocks)
     assert summary == "Summary text"


### PR DESCRIPTION
## Summary
- generalize lab summarizer to `summarize_blocks`
- update cleaner default summarizer
- update scripts using the new function
- adjust summarizer tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b22213058832685fbc350366b2a25