### PR TITLE
Add portal test runner CLI

### DIFF
--- a/app/adapters/test_portal.py
+++ b/app/adapters/test_portal.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List
+
+
+def scrape_test_portal(*_args, **_kwargs) -> Dict[str, List[str]]:
+    """Return paths to sample HTML and PDF files for testing."""
+    base = Path(__file__).resolve().parents[2] / "tests" / "sample_data"
+    html = base / "visit.html"
+    pdf = base / "labs.pdf"
+    if not base.exists():
+        base.mkdir(parents=True, exist_ok=True)
+        # create simple files if missing
+        html.write_text(
+            "<div class='visit'><span class='date'>2023-01-01</span>"
+            "<span class='provider'>Clinic</span><span class='doctor'>Dr. Z" \
+            "</span><p class='notes'>Test</p></div>",
+            encoding="utf-8",
+        )
+        # reuse helper from e2e_test_runner to create a small PDF
+        from scripts.e2e_test_runner import create_sample_pdf
+
+        create_sample_pdf(pdf)
+    return {"files": [str(html), str(pdf)]}

--- a/logs/portal_runs/test_portal_20250612_195339.json
+++ b/logs/portal_runs/test_portal_20250612_195339.json
@@ -1,0 +1,8 @@
+{
+  "portal": "test_portal",
+  "depth": 2,
+  "start_time": "2025-06-12T19:53:39.461896",
+  "success": true,
+  "end_time": "2025-06-12T19:53:39.889051",
+  "duration_seconds": 0.427155
+}

--- a/scripts/run_portal_test.py
+++ b/scripts/run_portal_test.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+"""Command line tool to execute the ETL pipeline for a single portal.
+
+This script is intended for manual testing of the full pipeline. It calls
+``run_etl_for_portal`` from ``app.orchestrator`` and records a summary
+of the run to ``logs/portal_runs/<portal>_<timestamp>.json``.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import traceback
+from datetime import datetime
+from pathlib import Path
+import shutil
+
+# Ensure ``app`` package imports resolve when run directly
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run ETL pipeline for a portal")
+    parser.add_argument("--portal", required=True, help="Portal name (module)")
+    parser.add_argument(
+        "--depth",
+        type=int,
+        default=3,
+        help="Max crawl depth/pages (stored in MAX_DEPTH env)",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Print stack traces if the pipeline fails",
+    )
+    args = parser.parse_args()
+
+    # Use an in-memory Redis instance for test runs unless disabled
+    if os.getenv("USE_FAKE_REDIS", "1") == "1":
+        import importlib
+        import fakeredis
+
+        import app.storage.redis as redis_module
+
+        redis_module = importlib.reload(redis_module)
+        redis_module._redis_client = fakeredis.FakeRedis(decode_responses=True)
+
+    # Import here so pytest collection doesn't require environment variables
+    from app.orchestrator import run_etl_for_portal
+
+    os.environ["MAX_DEPTH"] = str(args.depth)
+
+    start = datetime.utcnow()
+    summary = {
+        "portal": args.portal,
+        "depth": args.depth,
+        "start_time": start.isoformat(),
+    }
+
+    try:
+        run_etl_for_portal(args.portal)
+        summary["success"] = True
+    except Exception as exc:  # noqa: BLE001
+        summary["success"] = False
+        summary["error"] = str(exc)
+        if args.debug:
+            traceback.print_exc()
+
+    end = datetime.utcnow()
+    summary["end_time"] = end.isoformat()
+    summary["duration_seconds"] = (end - start).total_seconds()
+
+    log_dir = ROOT_DIR / "logs" / "portal_runs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    ts = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    log_path = log_dir / f"{args.portal}_{ts}.json"
+
+    # Copy any challenge screenshots to the log directory
+    screenshots = list(Path("/tmp").glob("challenge_*.png"))
+    copied = []
+    for sc in screenshots:
+        if sc.stat().st_mtime < start.timestamp():
+            continue
+        dest = log_dir / sc.name
+        try:
+            shutil.copy(sc, dest)
+            copied.append(dest.name)
+        except Exception:
+            continue
+    if copied:
+        summary["screenshots"] = copied
+
+    with log_path.open("w", encoding="utf-8") as fh:
+        json.dump(summary, fh, indent=2)
+
+    print(f"Run complete. Log saved to {log_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `run_portal_test.py` CLI for running the ETL pipeline end-to-end
- include sample adapter `test_portal` used for local testing
- store example run output in `logs/portal_runs`

## Testing
- `pytest -q`
- `python scripts/run_portal_test.py --portal test_portal --depth 2 --debug`

------
https://chatgpt.com/codex/tasks/task_e_684b2effbd98832697ee04d1c4c9f1cf