### PR TITLE
Implement Playwright-based test portal adapter

### DIFF
--- a/app/adapters/test_portal.py
+++ b/app/adapters/test_portal.py
@@ -1,25 +1,74 @@
+"""Playwright test adapter that generates sample pages for pipeline QA."""
+
 from __future__ import annotations
 
+import os
+import uuid
 from pathlib import Path
 from typing import Dict, List
 
+from dotenv import load_dotenv
+from playwright.async_api import async_playwright
 
-def scrape_test_portal(*_args, **_kwargs) -> Dict[str, List[str]]:
-    """Return paths to sample HTML and PDF files for testing."""
-    base = Path(__file__).resolve().parents[2] / "tests" / "sample_data"
-    html = base / "visit.html"
-    pdf = base / "labs.pdf"
-    if not base.exists():
-        base.mkdir(parents=True, exist_ok=True)
-        # create simple files if missing
-        html.write_text(
-            "<div class='visit'><span class='date'>2023-01-01</span>"
-            "<span class='provider'>Clinic</span><span class='doctor'>Dr. Z" \
-            "</span><p class='notes'>Test</p></div>",
-            encoding="utf-8",
-        )
-        # reuse helper from e2e_test_runner to create a small PDF
-        from scripts.e2e_test_runner import create_sample_pdf
 
-        create_sample_pdf(pdf)
-    return {"files": [str(html), str(pdf)]}
+async def scrape_test_portal(*_args, **_kwargs) -> Dict[str, List[str]]:
+    """Generate mock portal pages and return saved file paths.
+
+    The adapter creates a fake login page, a dashboard page linking to a PDF,
+    and a visit summary page. It saves all content under ``/tmp`` with unique
+    filenames so the orchestrator can parse them like real portal output.
+    """
+
+    load_dotenv()
+
+    username = os.getenv("TEST_PORTAL_USERNAME") or os.getenv("MOCK_USERNAME") or "user"
+    password = os.getenv("TEST_PORTAL_PASSWORD") or os.getenv("MOCK_PASSWORD") or "pass"
+
+    tmp_dir = Path("/tmp")
+    tmp_dir.mkdir(exist_ok=True)
+    uid = uuid.uuid4().hex[:8]
+
+    login_path = tmp_dir / f"test_login_{uid}.html"
+    dash_path = tmp_dir / f"test_dash_{uid}.html"
+    visit_path = tmp_dir / f"test_visit_{uid}.html"
+    pdf_path = tmp_dir / f"test_labs_{uid}.pdf"
+
+    login_html = f"""
+    <html><body>
+      <form id='login' action='{dash_path.name}' method='get'>
+        <input id='username' name='username'>
+        <input id='password' name='password' type='password'>
+        <button id='login-btn' type='submit'>Login</button>
+      </form>
+    </body></html>
+    """
+    login_path.write_text(login_html, encoding="utf-8")
+
+    dash_html = f"""
+    <html><body>
+      <a href='{pdf_path.name}'>Lab Results</a>
+      <a href='{visit_path.name}'>Visit Summary</a>
+    </body></html>
+    """
+    dash_path.write_text(dash_html, encoding="utf-8")
+
+    # Reuse helper to create small sample files
+    from scripts.e2e_test_runner import create_sample_pdf, create_sample_html
+
+    create_sample_pdf(pdf_path)
+    create_sample_html(visit_path)
+
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=True)
+        page = await browser.new_page()
+        await page.goto(login_path.as_uri())
+        await page.fill("#username", username)
+        await page.fill("#password", password)
+        await page.click("#login-btn")
+        await page.wait_for_load_state("load")
+        await browser.close()
+
+    return {
+        "files": [str(dash_path), str(visit_path), str(pdf_path)],
+        "summary": {"pages": 2, "pdf_count": 1},
+    }


### PR DESCRIPTION
## Summary
- overhaul `test_portal` adapter to generate mock HTML/PDF content
- create fake login and dashboard pages using Playwright
- return saved file paths for orchestrator processing

## Testing
- `pytest -q`
- `python scripts/run_portal_test.py --portal test_portal --debug` *(fails: OpenAI API missing)*

------
https://chatgpt.com/codex/tasks/task_e_684b3975d6888326ae4f5e0b13bcf152