### PR TITLE
Add logging for ETL steps

### DIFF
--- a/app/adapters/common/challenges.py
+++ b/app/adapters/common/challenges.py
@@ -3,9 +3,17 @@ from __future__ import annotations
 import asyncio
 import uuid
 from pathlib import Path
+import logging
 
 from app.storage import redis as redis_store
 from app.storage import audit
+
+logger = logging.getLogger(__name__)
+if not logger.handlers:
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    logger.addHandler(handler)
+logger.setLevel(logging.INFO)
 
 # Time to keep challenge info in Redis (seconds)
 TTL_SECONDS = 600
@@ -42,7 +50,7 @@ async def prompt_user(page, description: str = "") -> str:
         )
 
     audit.log_event("system", "challenge_prompt", {"id": challenge_id})
-    print(f"[pause] Challenge {challenge_id} saved {screenshot_path}")
+    logger.info("[pause] Challenge %s saved %s", challenge_id, screenshot_path)
     return await _await_response(challenge_id)
 
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,7 +1,8 @@
 import os
+import logging
 
 
-def test_run_etl_for_portal(monkeypatch, tmp_path, capsys):
+def test_run_etl_for_portal(monkeypatch, tmp_path, caplog):
     os.environ["DATABASE_URL"] = "sqlite:///:memory:"
 
     html_file = tmp_path / "dash.html"
@@ -85,6 +86,7 @@ def test_run_etl_for_portal(monkeypatch, tmp_path, capsys):
 
     from app.orchestrator import run_etl_for_portal
 
+    caplog.set_level(logging.INFO)
     run_etl_for_portal("portal_a")
 
     assert deleted["called"] is True
@@ -95,14 +97,14 @@ def test_run_etl_for_portal(monkeypatch, tmp_path, capsys):
     assert inserted["labs"] == labs
     assert inserted["visits"] == visits
 
-    captured = capsys.readouterr()
-    assert "Starting pipeline for portal_a" in captured.out
-    assert "Retrieving credentials for portal_a" in captured.out
-    assert "Credentials found for portal_a" in captured.out
-    assert "Deleted credentials for portal_a" in captured.out
-    assert "Pipeline for portal_a complete" in captured.out
+    logs = caplog.text
+    assert "Starting pipeline for portal_a" in logs
+    assert "Retrieving credentials for portal_a" in logs
+    assert "Credentials found for portal_a" in logs
+    assert "Deleted credentials for portal_a" in logs
+    assert "Pipeline for portal_a complete" in logs
 
-def test_orchestrator_handles_challenge(monkeypatch, tmp_path, capsys):
+def test_orchestrator_handles_challenge(monkeypatch, tmp_path, caplog):
     os.environ["DATABASE_URL"] = "sqlite:///:memory:"
 
     html_file = tmp_path / "dash.html"
@@ -176,8 +178,9 @@ def test_orchestrator_handles_challenge(monkeypatch, tmp_path, capsys):
 
     from app.orchestrator import run_etl_for_portal
 
+    caplog.set_level(logging.INFO)
     run_etl_for_portal("portal_a")
 
-    captured = capsys.readouterr()
-    assert "Waiting for challenge cid" in captured.out
-    assert "Resuming challenge cid" in captured.out
+    logs = caplog.text
+    assert "Waiting for challenge cid" in logs
+    assert "Resuming challenge cid" in logs


### PR DESCRIPTION
## Summary
- replace print statements in `run_etl_for_portal` with `logging`
- add logger to challenge helper
- adjust orchestrator tests to capture logging output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b3ff228108326a9c860bbef1fa464