### PR TITLE
Fix dynamic import for test portal

### DIFF
--- a/app/adapters/test_portal.py
+++ b/app/adapters/test_portal.py
@@ -9,6 +9,7 @@ from typing import Dict, List
 
 from dotenv import load_dotenv
 from playwright.async_api import async_playwright
+import sys
 
 
 async def scrape_test_portal(*_args, **_kwargs) -> Dict[str, List[str]]:
@@ -52,8 +53,15 @@ async def scrape_test_portal(*_args, **_kwargs) -> Dict[str, List[str]]:
     """
     dash_path.write_text(dash_html, encoding="utf-8")
 
-    # Reuse helper to create small sample files
-    from scripts.e2e_test_runner import create_sample_pdf, create_sample_html
+    # Reuse helper to create small sample files. Import dynamically so the
+    # adapter works even when the repository root isn't on ``sys.path``.
+    try:
+        from scripts.e2e_test_runner import create_sample_pdf, create_sample_html
+    except ModuleNotFoundError:  # pragma: no cover - fallback for packaged runs
+        root = Path(__file__).resolve().parents[1]
+        if str(root) not in sys.path:
+            sys.path.insert(0, str(root))
+        from scripts.e2e_test_runner import create_sample_pdf, create_sample_html
 
     create_sample_pdf(pdf_path)
     create_sample_html(visit_path)

--- a/tests/test_test_portal_adapter.py
+++ b/tests/test_test_portal_adapter.py
@@ -1,0 +1,52 @@
+import asyncio
+import sys
+from pathlib import Path
+from contextlib import asynccontextmanager
+
+# ensure repo root on path
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import app.adapters.test_portal as test_portal
+
+
+@asynccontextmanager
+async def _dummy_playwright():
+    class DummyPage:
+        async def goto(self, url):
+            pass
+
+        async def fill(self, selector, value):
+            pass
+
+        async def click(self, selector):
+            pass
+
+        async def wait_for_load_state(self, state):
+            pass
+
+    class DummyBrowser:
+        async def new_page(self):
+            return DummyPage()
+
+        async def close(self):
+            pass
+
+    class DummyChromium:
+        async def launch(self, headless=True):
+            return DummyBrowser()
+
+    class DummyCtx:
+        def __init__(self):
+            self.chromium = DummyChromium()
+
+    yield DummyCtx()
+
+
+def test_scrape_test_portal(monkeypatch):
+    monkeypatch.setattr(test_portal, "async_playwright", _dummy_playwright)
+    result = asyncio.run(test_portal.scrape_test_portal())
+    assert sorted(Path(p).suffix for p in result["files"]) == [".html", ".html", ".pdf"]
+    for p in result["files"]:
+        assert Path(p).exists()


### PR DESCRIPTION
## Summary
- make `test_portal` adapter resilient when repo root isn't on `sys.path`
- add regression test for `test_portal` adapter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b43293fa88326967b0ecee674e8ab