### PR TITLE
Move sample file helpers into package

### DIFF
--- a/app/adapters/test_portal.py
+++ b/app/adapters/test_portal.py
@@ -7,9 +7,16 @@ import uuid
 from pathlib import Path
 from typing import Dict, List
 
+import sys
+
 from dotenv import load_dotenv
 from playwright.async_api import async_playwright
-import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.utils.sample_files import create_sample_pdf, create_sample_html
 
 
 async def scrape_test_portal(*_args, **_kwargs) -> Dict[str, List[str]]:
@@ -53,16 +60,7 @@ async def scrape_test_portal(*_args, **_kwargs) -> Dict[str, List[str]]:
     """
     dash_path.write_text(dash_html, encoding="utf-8")
 
-    # Reuse helper to create small sample files. Import dynamically so the
-    # adapter works even when the repository root isn't on ``sys.path``.
-    try:
-        from scripts.e2e_test_runner import create_sample_pdf, create_sample_html
-    except ModuleNotFoundError:  # pragma: no cover - fallback for packaged runs
-        root = Path(__file__).resolve().parents[1]
-        if str(root) not in sys.path:
-            sys.path.insert(0, str(root))
-        from scripts.e2e_test_runner import create_sample_pdf, create_sample_html
-
+    # Create small sample PDF and HTML files used for downstream parsing tests.
     create_sample_pdf(pdf_path)
     create_sample_html(visit_path)
 

--- a/app/utils/sample_files.py
+++ b/app/utils/sample_files.py
@@ -1,0 +1,31 @@
+"""Utility helpers to generate small sample files for tests and demos."""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def create_sample_pdf(path: Path) -> None:
+    """Create a simple PDF with two lab result lines."""
+    import fitz  # PyMuPDF
+
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text((72, 72), "Cholesterol 5.8 mmol/L 2023-05-01")
+    page.insert_text((72, 90), "Hemoglobin 13.5 g/dL 2023-05-02")
+    doc.save(path)
+    doc.close()
+
+
+def create_sample_html(path: Path) -> None:
+    """Create simple HTML with a single visit summary."""
+    html = """
+    <html><body>
+      <div class='visit'>
+        <span class='date'>2023-06-01</span>
+        <span class='provider'>General Hospital</span>
+        <span class='doctor'>Dr. Jones</span>
+        <p class='notes'>Routine check</p>
+      </div>
+    </body></html>
+    """
+    path.write_text(html, encoding="utf-8")

--- a/scripts/dev_seed_and_preview.py
+++ b/scripts/dev_seed_and_preview.py
@@ -18,33 +18,8 @@ from app.processors.visit_html_parser import extract_visit_summaries
 from app.processors.structuring import insert_lab_results, insert_visit_summaries
 from app.prompts.summarizer import summarize_blocks
 from app.api.rag import ask_question, QueryRequest
+from app.utils.sample_files import create_sample_pdf, create_sample_html
 
-
-def create_sample_pdf(path: Path) -> None:
-    """Create a small PDF with two lab lines for demo purposes."""
-    import fitz  # PyMuPDF
-
-    doc = fitz.open()
-    page = doc.new_page()
-    page.insert_text((72, 72), "Cholesterol 5.8 mmol/L 2023-05-01")
-    page.insert_text((72, 90), "Hemoglobin 13.5 g/dL 2023-05-02")
-    doc.save(path)
-    doc.close()
-
-
-def create_sample_html(path: Path) -> None:
-    """Create simple HTML with a single visit summary."""
-    html = """
-    <html><body>
-      <div class='visit'>
-        <span class='date'>2023-06-01</span>
-        <span class='provider'>General Hospital</span>
-        <span class='doctor'>Dr. Jones</span>
-        <p class='notes'>Routine check</p>
-      </div>
-    </body></html>
-    """
-    path.write_text(html, encoding="utf-8")
 
 
 def _maybe_mock_openai() -> None:

--- a/scripts/e2e_test_runner.py
+++ b/scripts/e2e_test_runner.py
@@ -21,6 +21,8 @@ from pathlib import Path
 from typing import Dict, List
 import asyncio
 
+from app.utils.sample_files import create_sample_pdf, create_sample_html
+
 # Ensure repo root is on sys.path so `app` package resolves
 ROOT_DIR = Path(__file__).resolve().parents[1]
 if str(ROOT_DIR) not in sys.path:
@@ -28,37 +30,6 @@ if str(ROOT_DIR) not in sys.path:
 
 import openai
 import httpx
-
-
-# ---------------------------------------------------------------------------
-# Utilities to create sample input files
-# ---------------------------------------------------------------------------
-
-def create_sample_pdf(path: Path) -> None:
-    import fitz  # PyMuPDF
-
-    doc = fitz.open()
-    page = doc.new_page()
-    page.insert_text((72, 72), "Cholesterol 5.8 mmol/L 2023-05-01")
-    page.insert_text((72, 90), "Hemoglobin 13.5 g/dL 2023-05-02")
-    doc.save(path)
-    doc.close()
-
-
-def create_sample_html(path: Path) -> None:
-    html = """
-    <html><body>
-      <div class='visit'>
-        <span class='date'>2023-06-01</span>
-        <span class='provider'>General Hospital</span>
-        <span class='doctor'>Dr. Jones</span>
-        <p class='notes'>Routine check</p>
-      </div>
-    </body></html>
-    """
-    path.write_text(html, encoding="utf-8")
-
-
 # ---------------------------------------------------------------------------
 # Main pipeline logic
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- provide `create_sample_pdf` and `create_sample_html` helpers in new `app.utils.sample_files` module
- simplify `test_portal` adapter to call local helpers
- adjust scripts to import the shared helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b7b63954883269430056eb92696fd