### PR TITLE
Fix OpenAI calls and centralize LLM utility

### DIFF
--- a/app/api/rag.py
+++ b/app/api/rag.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 from pydantic import BaseModel
-import openai
+
+from app.utils import chat_completion
 
 
 
@@ -48,9 +49,8 @@ def ask_question(payload: QueryRequest) -> dict[str, str]:
 
     prompt = f"{context}\n\nQuestion: {payload.query}"
 
-    response = openai.ChatCompletion.create(
+    answer = chat_completion(
+        [{"role": "user", "content": prompt}],
         model="gpt-3.5-turbo",
-        messages=[{"role": "user", "content": prompt}],
     )
-    answer = response["choices"][0]["message"]["content"].strip()
     return {"answer": answer}

--- a/app/extractor.py
+++ b/app/extractor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from typing import List, Dict
 
-import openai
+from app.utils import chat_completion
 from bs4 import BeautifulSoup
 
 
@@ -51,11 +51,10 @@ def extract_relevant_content(
 
     for chunk in chunks:
         prompt = PROMPT_TEMPLATE.format(chunk=chunk)
-        response = openai.ChatCompletion.create(
+        content = chat_completion(
+            [{"role": "user", "content": prompt}],
             model="gpt-3.5-turbo",
-            messages=[{"role": "user", "content": prompt}],
         )
-        content = response["choices"][0]["message"]["content"]
         try:
             entries = json.loads(content)
         except json.JSONDecodeError:

--- a/app/prompts/summarizer.py
+++ b/app/prompts/summarizer.py
@@ -1,5 +1,6 @@
-import openai
 from typing import List, Dict
+
+from app.utils import chat_completion
 
 
 def summarize_blocks(blocks: List[Dict[str, str]]) -> str:
@@ -23,11 +24,10 @@ def summarize_blocks(blocks: List[Dict[str, str]]) -> str:
     )
 
     combined_text = "\n".join(block.get("text", "") for block in blocks)
-    response = openai.ChatCompletion.create(
-        model="gpt-3.5-turbo",
-        messages=[
+    return chat_completion(
+        [
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": combined_text},
         ],
+        model="gpt-3.5-turbo",
     )
-    return response["choices"][0]["message"]["content"].strip()

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -1,0 +1,1 @@
+from .llm import chat_completion

--- a/app/utils/llm.py
+++ b/app/utils/llm.py
@@ -1,0 +1,8 @@
+import openai
+from typing import List, Dict, Any
+
+
+def chat_completion(messages: List[Dict[str, str]], *, model: str = "gpt-3.5-turbo", **kwargs: Any) -> str:
+    """Return the assistant message content from an OpenAI chat completion."""
+    response = openai.chat.completions.create(model=model, messages=messages, **kwargs)
+    return response.choices[0].message.content.strip()

--- a/scripts/dev_seed_and_preview.py
+++ b/scripts/dev_seed_and_preview.py
@@ -6,7 +6,7 @@ import tempfile
 from pathlib import Path
 from typing import List, Dict
 
-import openai
+from app.utils import llm
 
 # Ensure repo root on path for `app` imports when executed directly
 ROOT_DIR = Path(__file__).resolve().parents[1]
@@ -27,13 +27,13 @@ def _maybe_mock_openai() -> None:
     if os.getenv("OPENAI_API_KEY"):
         return
 
-    def fake_create(*args, **kwargs):
-        content = kwargs["messages"][0]["content"]
+    def fake_create(messages, **_kwargs):
+        content = messages[0]["content"]
         if "Question:" in content:
-            return {"choices": [{"message": {"content": "Mock answer"}}]}
-        return {"choices": [{"message": {"content": "Mock summary"}}]}
+            return "Mock answer"
+        return "Mock summary"
 
-    openai.ChatCompletion.create = fake_create
+    llm.chat_completion = fake_create
 
 
 def load_lab_data(path: Path) -> List[Dict]:

--- a/scripts/e2e_test_runner.py
+++ b/scripts/e2e_test_runner.py
@@ -28,8 +28,8 @@ ROOT_DIR = Path(__file__).resolve().parents[1]
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
-import openai
 import httpx
+from app.utils import llm
 # ---------------------------------------------------------------------------
 # Main pipeline logic
 # ---------------------------------------------------------------------------
@@ -88,13 +88,13 @@ def main() -> None:
         # ------------------------------------------------------------------
         # Step 3: Summarize lab results
         # ------------------------------------------------------------------
-        def fake_create(*args, **kwargs):
-            prompt = kwargs["messages"][0]["content"]
+        def fake_create(messages, **_kwargs):
+            prompt = messages[0]["content"]
             if "Question:" in prompt:
-                return {"choices": [{"message": {"content": "Mock answer"}}]}
-            return {"choices": [{"message": {"content": "Mock summary"}}]}
+                return "Mock answer"
+            return "Mock summary"
 
-        openai.ChatCompletion.create = fake_create
+        llm.chat_completion = fake_create
 
         from app.prompts.summarizer import summarize_blocks
 

--- a/task_guides/reports/task_13_lab_summary_prompt_report.md
+++ b/task_guides/reports/task_13_lab_summary_prompt_report.md
@@ -3,7 +3,7 @@
 ## ✅ Summary
 Implemented `summarize_lab_results()` using:
 - `load_prompt()` to render `summarize_lab_results.yaml`
-- `openai.ChatCompletion.create()` to call LLM with user prompt
+- `app.utils.llm.chat_completion()` to call LLM with user prompt
 - Returns the text of the response
 
 ## 📂 Files Created

--- a/task_guides/task_13_lab_summary_prompt.md
+++ b/task_guides/task_13_lab_summary_prompt.md
@@ -10,7 +10,7 @@ Generate a readable health summary from structured lab results using OpenAI and 
 - Load the `summarize_lab_results.yaml` template from `app/prompts/`
 - Accept list of `LabResult` dicts as input
 - Render the template into a string using field substitution
-- Use `openai.ChatCompletion.create` to submit the prompt
+- Use `app.utils.llm.chat_completion` to submit the prompt
 - Return the natural-language summary text
 
 ## 🧪 Test

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ if "app" not in inspect.signature(httpx.Client.__init__).parameters:
             portal_factory=self._portal_factory,
             raise_server_exceptions=raise_server_exceptions,
             root_path=root_path,
+            client=("testserver", 80),
             app_state=self.app_state,
         )
         if headers is None:

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -1,20 +1,17 @@
-import openai
-
 from app.extractor import extract_relevant_content
+from app.utils import llm
 
 
 def test_extract_relevant_content(monkeypatch):
     calls = []
 
-    def fake_create(*args, **kwargs):
-        calls.append(kwargs["messages"][0]["content"])
-        return {
-            "choices": [
-                {"message": {"content": '[{"type": "lab_result", "text": "Sodium 140 mmol/L"}]'}}
-            ]
-        }
+    def fake_create(messages, **_kwargs):
+        calls.append(messages[0]["content"])
+        return '[{"type": "lab_result", "text": "Sodium 140 mmol/L"}]'
 
-    monkeypatch.setattr(openai.ChatCompletion, "create", fake_create)
+    monkeypatch.setattr(llm, "chat_completion", fake_create)
+    import app.extractor as extractor_module
+    monkeypatch.setattr(extractor_module, "chat_completion", fake_create)
 
     html = "<html><body><p>Sodium 140 mmol/L</p><p>Another value</p></body></html>"
     results = extract_relevant_content(html, "https://portal.test/page", max_chunk_chars=20)

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -1,13 +1,15 @@
-import openai
 from app.prompts.summarizer import summarize_blocks
+from app.utils import llm
 
 
 def test_summarize_blocks(monkeypatch):
     # Prepare fake response
-    def fake_create(*args, **kwargs):
-        return {"choices": [{"message": {"content": "Summary text"}}]}
+    def fake_create(messages, **_kwargs):
+        return "Summary text"
 
-    monkeypatch.setattr(openai.ChatCompletion, "create", fake_create)
+    monkeypatch.setattr(llm, "chat_completion", fake_create)
+    import app.prompts.summarizer as summarizer_module
+    monkeypatch.setattr(summarizer_module, "chat_completion", fake_create)
 
     blocks = [
         {"text": "Patient reports mild headache."},


### PR DESCRIPTION
## Summary
- update OpenAI API usage to use `openai.chat.completions.create`
- add `app/utils/llm.py` helper and refactor modules to use it
- update scripts and tests to patch the new helper
- refresh task guides to mention the helper
- adjust Starlette test client compatibility

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b7d1d022483268e88a6f742f95b83