### PR TITLE
Add record export script with Markdown/PDF options

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,5 @@ cryptography
 pytest
 jinja2
 fakeredis
+markdown2
+reportlab

--- a/scripts/export_records.py
+++ b/scripts/export_records.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python
+"""Export structured DB records to JSON, Markdown, or PDF."""
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import os
+import sys
+from pathlib import Path
+from typing import List, Tuple
+
+import markdown2
+from reportlab.lib.pagesizes import letter
+from reportlab.pdfgen import canvas
+
+# Ensure repo root is on path
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+
+
+
+def _init_session(db_path: str):
+    """Initialize DB session for ``db_path`` and return (session, models)."""
+    os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"
+    import app.storage.db as db_module
+    import app.storage.models as models_module
+
+    db_module = importlib.reload(db_module)
+    models_module = importlib.reload(models_module)
+    db_module.init_db()
+    return db_module.SessionLocal(), models_module
+
+
+def _fetch_records(session, models_module) -> Tuple[List, List, List]:
+    labs = (
+        session.query(models_module.LabResult)
+        .order_by(models_module.LabResult.date)
+        .all()
+    )
+    visits = (
+        session.query(models_module.VisitSummary)
+        .order_by(models_module.VisitSummary.date)
+        .all()
+    )
+    try:
+        structured = (
+            session.query(models_module.StructuredRecord)
+            .order_by(models_module.StructuredRecord.id)
+            .all()
+        )
+    except Exception:  # pragma: no cover - older DBs may lack table
+        structured = []
+    return labs, visits, structured
+
+
+def _records_to_markdown(labs, visits, structured) -> str:
+    lines = []
+    if labs:
+        lines.append("## Lab Results")
+        for lab in labs:
+            lines.append(
+                f"- {lab.date} {lab.test_name} {lab.value} {lab.units}")
+        lines.append("")
+    if visits:
+        lines.append("## Visit Summaries")
+        for visit in visits:
+            lines.append(
+                f"- {visit.date} {visit.provider} {visit.doctor}: {visit.notes}")
+        lines.append("")
+    if structured:
+        lines.append("## Structured Records")
+        for rec in structured:
+            base = f"- [{rec.type}] {rec.text}"
+            if rec.source_url:
+                base += f" ({rec.source_url})"
+            lines.append(base)
+    return "\n".join(lines)
+
+
+def _markdown_to_pdf(md: str, out_path: Path) -> None:
+    """Render ``md`` to a simple PDF using reportlab."""
+    pdf = canvas.Canvas(str(out_path), pagesize=letter)
+    text = pdf.beginText(40, 750)
+    for line in md.splitlines():
+        text.textLine(line)
+        if text.getY() <= 40:
+            pdf.drawText(text)
+            pdf.showPage()
+            text = pdf.beginText(40, 750)
+    pdf.drawText(text)
+    pdf.save()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Export structured DB records")
+    parser.add_argument("--db", default="health_data.db", help="SQLite DB path")
+    parser.add_argument(
+        "--format",
+        choices=["json", "markdown", "pdf"],
+        default="json",
+        help="Output format",
+    )
+    parser.add_argument("--output", required=True, help="Output file path")
+    args = parser.parse_args()
+
+    session, models_module = _init_session(args.db)
+    labs, visits, structured = _fetch_records(session, models_module)
+    session.close()
+
+    out_path = Path(args.output)
+
+    if args.format == "json":
+        data = {
+            "lab_results": [
+                {
+                    "test_name": l.test_name,
+                    "value": l.value,
+                    "units": l.units,
+                    "date": l.date.isoformat(),
+                }
+                for l in labs
+            ],
+            "visit_summaries": [
+                {
+                    "provider": v.provider,
+                    "doctor": v.doctor,
+                    "notes": v.notes,
+                    "date": v.date.isoformat(),
+                }
+                for v in visits
+            ],
+            "structured_records": [
+                {
+                    "portal": r.portal,
+                    "type": r.type,
+                    "text": r.text,
+                    "source_url": r.source_url,
+                    "date_created": r.date_created.isoformat(),
+                }
+                for r in structured
+            ],
+        }
+        out_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    else:
+        md = _records_to_markdown(labs, visits, structured)
+        if args.format == "markdown":
+            out_path.write_text(md, encoding="utf-8")
+        else:  # pdf
+            _markdown_to_pdf(md, out_path)
+
+    print(f"Exported records to {out_path}")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/tests/test_export_records.py
+++ b/tests/test_export_records.py
@@ -1,0 +1,122 @@
+import importlib
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts import export_records
+from app.processors.structuring import insert_lab_results, insert_visit_summaries
+from app.storage.structured import insert_structured_records
+
+
+def _setup_db(tmp_path: Path, monkeypatch) -> Path:
+    db_path = tmp_path / "sample.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    import app.storage.db as db_module
+    import app.storage.models as models_module
+
+    db_module = importlib.reload(db_module)
+    models_module = importlib.reload(models_module)
+    db_module.init_db()
+    session = db_module.SessionLocal()
+
+    insert_lab_results(
+        session,
+        [
+            {
+                "test_name": "Cholesterol",
+                "value": 5.8,
+                "units": "mmol/L",
+                "date": "2023-05-01",
+            }
+        ],
+    )
+    insert_visit_summaries(
+        session,
+        [
+            {
+                "provider": "Clinic",
+                "doctor": "Dr. Jones",
+                "notes": "Routine",
+                "date": "2023-06-01",
+            }
+        ],
+    )
+    insert_structured_records(
+        session,
+        [
+            {
+                "portal": "test_portal",
+                "type": "note",
+                "text": "Some note",
+                "source_url": "url",
+            }
+        ],
+    )
+    session.close()
+    return db_path
+
+
+def test_export_records_all_formats(tmp_path, monkeypatch):
+    db = _setup_db(tmp_path, monkeypatch)
+    out_json = tmp_path / "out.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "export_records.py",
+            "--db",
+            str(db),
+            "--output",
+            str(out_json),
+        ],
+    )
+    export_records.main()
+    data = json.loads(out_json.read_text())
+    assert data["lab_results"][0]["test_name"] == "Cholesterol"
+
+    out_md = tmp_path / "out.md"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "export_records.py",
+            "--db",
+            str(db),
+            "--format",
+            "markdown",
+            "--output",
+            str(out_md),
+        ],
+    )
+    export_records.main()
+    text = out_md.read_text()
+    assert "## Lab Results" in text
+
+    out_pdf = tmp_path / "out.pdf"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "export_records.py",
+            "--db",
+            str(db),
+            "--format",
+            "pdf",
+            "--output",
+            str(out_pdf),
+        ],
+    )
+    export_records.main()
+    assert out_pdf.exists() and out_pdf.stat().st_size > 0
+
+    # reload DB modules to avoid affecting other tests
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
+    import app.storage.db as db_module
+    import app.storage.models as models_module
+    importlib.reload(db_module)
+    importlib.reload(models_module)


### PR DESCRIPTION
## Summary
- add `scripts/export_records.py` CLI to dump LabResult and VisitSummary data
- support JSON, Markdown, and PDF outputs
- include new dependencies `markdown2` and `reportlab`
- provide unit test for export script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c0e006dd083268a5eec1714df4b37