### PR TITLE
Add ETL confirmation endpoint

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -2,7 +2,9 @@ from fastapi import APIRouter
 
 from .rag import router as rag_router
 from .upload import router as upload_router
+from .etl import router as etl_router
 
 router = APIRouter()
 router.include_router(rag_router)
 router.include_router(upload_router)
+router.include_router(etl_router)

--- a/app/api/etl.py
+++ b/app/api/etl.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from datetime import datetime
+import os
+
+from fastapi import APIRouter, Form, Query
+from fastapi.responses import JSONResponse
+
+from app.storage import blob, audit
+
+router = APIRouter()
+
+def _dry_run() -> bool:
+    return os.getenv("DRY_RUN", "0").lower() in {"1", "true", "yes"}
+
+
+@router.get("/status")
+def upload_status(session_key: str = Query(...)) -> JSONResponse:
+    """Return prompt asking to start analysis for uploaded files."""
+    files = blob.list_blobs(session_key)
+    if not files:
+        return JSONResponse({"prompt": ""})
+    msg = f"You've uploaded {len(files)} files. Would you like to analyze them now?"
+    return JSONResponse({"prompt": msg})
+
+
+@router.post("/process")
+def process_files(session_key: str = Form(...)) -> JSONResponse:
+    """Run ETL pipeline after user confirmation."""
+    audit.log_event(session_key, "consent_given", {"timestamp": datetime.utcnow().isoformat()})
+    if not _dry_run():
+        from app.orchestrator import run_etl_from_blobs
+        run_etl_from_blobs(session_key)
+        status = "processing complete"
+    else:
+        status = "dry-run"
+    return JSONResponse({"status": status})

--- a/tests/test_process_api.py
+++ b/tests/test_process_api.py
@@ -1,0 +1,46 @@
+import json
+import importlib
+import sys
+from pathlib import Path
+from fastapi.testclient import TestClient
+from fastapi import FastAPI
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def setup_app(monkeypatch, tmp_path):
+    log_file = tmp_path / "audit.json"
+    monkeypatch.setenv("AUDIT_LOG", str(log_file))
+    from cryptography.fernet import Fernet
+    monkeypatch.setenv("FERNET_KEY", Fernet.generate_key().decode())
+    importlib.reload(importlib.import_module("app.storage.audit"))
+
+    blob_module = importlib.import_module("app.storage.blob")
+    monkeypatch.setattr(blob_module, "list_blobs", lambda prefix: [f"{prefix}/a.pdf", f"{prefix}/b.html"])
+
+    called = {}
+    monkeypatch.setattr(importlib.import_module("app.orchestrator"), "run_etl_from_blobs", lambda prefix: called.setdefault("prefix", prefix))
+
+    etl_module = importlib.reload(importlib.import_module("app.api.etl"))
+    app = FastAPI()
+    app.include_router(etl_module.router)
+    client = TestClient(app)
+    return client, log_file, called
+
+
+def test_process_flow(monkeypatch, tmp_path):
+    client, log_file, called = setup_app(monkeypatch, tmp_path)
+
+    resp = client.get("/status", params={"session_key": "sess"})
+    assert resp.status_code == 200
+    assert "You\'ve uploaded 2 files" in resp.json()["prompt"]
+
+    resp = client.post("/process", data={"session_key": "sess"})
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "processing complete"
+    assert called["prefix"] == "sess"
+
+    logs = json.loads(log_file.read_text())
+    assert logs and logs[0]["action"] == "consent_given"


### PR DESCRIPTION
## Summary
- add `/status` endpoint to prompt analysis of uploaded files
- keep `/process` endpoint but make it POST only
- log consent and run ETL from blobs upon confirmation
- update tests for new chat-based flow

## Testing
- `pytest tests/test_process_api.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68503b1f62988326a35bf8588c84ec11