### PR TITLE
Add CLI for Azure Blob uploads

### DIFF
--- a/scripts/upload_to_blob.py
+++ b/scripts/upload_to_blob.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+"""Upload a local file to Azure Blob Storage for ETL processing."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+import httpx
+
+# Load environment variables from .env if present
+load_dotenv()
+
+# Ensure repo root is on sys.path
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from app.storage import blob
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Upload file to Azure Blob")
+    parser.add_argument("--session-key", required=True, help="Session identifier")
+    parser.add_argument("--file", required=True, help="Path to local file")
+    parser.add_argument("--portal", default="", help="Portal name for metadata")
+    args = parser.parse_args()
+
+    file_path = Path(args.file)
+    if not file_path.exists():
+        print(f"ERROR: File not found: {file_path}")
+        return
+
+    url = blob.generate_upload_url(args.session_key, file_path.name)
+
+    with file_path.open("rb") as fh:
+        resp = httpx.put(url, data=fh.read())
+    resp.raise_for_status()
+
+    blob.record_upload(args.session_key, args.portal, file_path.name)
+
+    blob_path = f"{args.session_key}/{file_path.name}"
+    print(f"Uploaded {file_path} to {blob_path} (status {resp.status_code})")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/tests/test_upload_to_blob.py
+++ b/tests/test_upload_to_blob.py
@@ -1,0 +1,55 @@
+import importlib
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def test_upload_to_blob(monkeypatch, tmp_path, capsys):
+    module = importlib.import_module("scripts.upload_to_blob")
+
+    file_path = tmp_path / "sample.txt"
+    file_path.write_text("hello")
+
+    generated = {}
+    monkeypatch.setattr(
+        module.blob,
+        "generate_upload_url",
+        lambda sess, filename: generated.setdefault("url", f"https://x/{sess}/{filename}")
+    )
+
+    put_called = {}
+
+    class Resp:
+        status_code = 201
+
+        def raise_for_status(self):
+            pass
+
+    def fake_put(url, data):
+        put_called["url"] = url
+        put_called["data"] = data
+        return Resp()
+
+    monkeypatch.setattr(module.httpx, "put", fake_put)
+
+    logged = {}
+    def fake_record(session, portal, filename):
+        logged.update({"session": session, "portal": portal, "filename": filename})
+    monkeypatch.setattr(module.blob, "record_upload", fake_record)
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["upload_to_blob.py", "--session-key", "sess", "--file", str(file_path), "--portal", "port"]
+    )
+
+    module.main()
+    out = capsys.readouterr().out
+    assert "Uploaded" in out
+    assert generated["url"] == "https://x/sess/sample.txt"
+    assert put_called["url"] == generated["url"]
+    assert put_called["data"] == b"hello"
+    assert logged == {"session": "sess", "portal": "port", "filename": "sample.txt"}


### PR DESCRIPTION
## Summary
- create `scripts/upload_to_blob.py` to upload local files to Azure Blob and log
- test the new CLI tool

## Testing
- `pip install -r requirements.txt`
- `playwright install` *(fails: missing host dependencies)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68506c00520c832680b644c312cc8c09