### PR TITLE
Refactor ETL outputs for privacy

### DIFF
--- a/app/api/etl.py
+++ b/app/api/etl.py
@@ -4,7 +4,6 @@ from datetime import datetime
 import os
 
 from fastapi import APIRouter, Form, Query
-from fastapi.responses import JSONResponse
 from fastapi.responses import HTMLResponse, JSONResponse
 
 from app.storage import blob, audit
@@ -50,8 +49,9 @@ def process_files(session_key: str = Form(...)) -> JSONResponse:
     audit.log_event(session_key, "consent_given", {"timestamp": datetime.utcnow().isoformat()})
     if not _dry_run():
         from app.orchestrator import run_etl_from_blobs
-        run_etl_from_blobs(session_key)
+        summary = run_etl_from_blobs(session_key)
         status = "processing complete"
     else:
         status = "dry-run"
-    return JSONResponse({"status": status})
+        summary = ""
+    return JSONResponse({"status": status, "summary": summary})

--- a/scripts/run_etl_from_blob.py
+++ b/scripts/run_etl_from_blob.py
@@ -24,13 +24,15 @@ def main() -> None:
 
     start = datetime.utcnow()
     try:
-        run_etl_from_blobs(args.prefix)
+        summary = run_etl_from_blobs(args.prefix)
         success = True
     except Exception as exc:  # noqa: BLE001
         print(f"ERROR: {exc}")
         success = False
     end = datetime.utcnow()
     print(f"Finished in {(end - start).total_seconds():.1f}s - success={success}")
+    if success:
+        print(summary)
 
 
 if __name__ == "__main__":

--- a/scripts/run_portal_test.py
+++ b/scripts/run_portal_test.py
@@ -64,7 +64,7 @@ def main() -> None:
     }
 
     try:
-        run_etl_for_portal(args.portal)
+        etl_summary = run_etl_for_portal(args.portal)
         summary["success"] = True
     except Exception as exc:  # noqa: BLE001
         summary["success"] = False
@@ -76,30 +76,10 @@ def main() -> None:
     summary["end_time"] = end.isoformat()
     summary["duration_seconds"] = (end - start).total_seconds()
 
-    log_dir = ROOT_DIR / "logs" / "portal_runs"
-    log_dir.mkdir(parents=True, exist_ok=True)
-    ts = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
-    log_path = log_dir / f"{args.portal}_{ts}.json"
-
-    # Copy any challenge screenshots to the log directory
-    screenshots = list(Path("/tmp").glob("challenge_*.png"))
-    copied = []
-    for sc in screenshots:
-        if sc.stat().st_mtime < start.timestamp():
-            continue
-        dest = log_dir / sc.name
-        try:
-            shutil.copy(sc, dest)
-            copied.append(dest.name)
-        except Exception:
-            continue
-    if copied:
-        summary["screenshots"] = copied
-
-    with log_path.open("w", encoding="utf-8") as fh:
-        json.dump(summary, fh, indent=2)
-
-    print(f"Run complete. Log saved to {log_path}")
+    print("Run complete. Summary:\n")
+    print(json.dumps(summary, indent=2))
+    if summary.get("success"):
+        print(etl_summary)
 
 
 if __name__ == "__main__":

--- a/tests/test_blob_etl.py
+++ b/tests/test_blob_etl.py
@@ -84,7 +84,7 @@ def test_run_etl_from_blobs(monkeypatch, tmp_path, caplog):
     from app.orchestrator import run_etl_from_blobs
 
     caplog.set_level(logging.INFO)
-    run_etl_from_blobs(prefix)
+    summary = run_etl_from_blobs(prefix)
 
     assert inserted["records"] and len(inserted["records"]) == 3
     assert inserted["session"] == prefix
@@ -94,7 +94,7 @@ def test_run_etl_from_blobs(monkeypatch, tmp_path, caplog):
     assert all(r["source"] == "operator" for r in inserted["records"])
 
     summary_file = Path("logs/blob_runs/user_session_summary.md")
-    assert summary_file.exists()
-    assert "Blob summary" in summary_file.read_text()
+    assert not summary_file.exists()
+    assert summary == "Blob summary"
 
     importlib.reload(orch_module)

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -103,7 +103,7 @@ def test_run_etl_for_portal(monkeypatch, tmp_path, caplog):
     from app.orchestrator import run_etl_for_portal
 
     caplog.set_level(logging.INFO)
-    run_etl_for_portal("portal_a")
+    summary = run_etl_for_portal("portal_a")
 
     assert deleted["called"] is True
 
@@ -117,8 +117,8 @@ def test_run_etl_for_portal(monkeypatch, tmp_path, caplog):
     assert rec["source"] == "operator"
 
     summary_file = Path("logs/portal_runs/portal_a_summary.md")
-    assert summary_file.exists()
-    assert "Run summary" in summary_file.read_text()
+    assert not summary_file.exists()
+    assert summary == "Run summary"
 
 
 def test_pdf_to_text_empty(monkeypatch, tmp_path, caplog):
@@ -219,11 +219,11 @@ def test_orchestrator_handles_challenge(monkeypatch, tmp_path, caplog):
     from app.orchestrator import run_etl_for_portal
 
     caplog.set_level(logging.INFO)
-    run_etl_for_portal("portal_a")
+    summary = run_etl_for_portal("portal_a")
 
     logs = caplog.text
     assert "Waiting for challenge cid" in logs
     assert "Resuming challenge cid" in logs
     summary_file = Path("logs/portal_runs/portal_a_summary.md")
-    assert summary_file.exists()
-    assert "Run summary" in summary_file.read_text()
+    assert not summary_file.exists()
+    assert summary == "Run summary"


### PR DESCRIPTION
## Summary
- return ETL summary text instead of writing logs
- log upload metadata to `audit/<session>.json` in blob storage
- update scripts to print summaries
- adapt process API to return inline summary
- update unit tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851c58b35cc8326a3e5c56a9920ed08