### PR TITLE
Secure APIs with bearer token dependency

### DIFF
--- a/app/api/consent.py
+++ b/app/api/consent.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 from datetime import datetime
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
 from app.storage import audit
+from app.auth.token import require_token
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(require_token)])
 
 
 class ConsentPayload(BaseModel):

--- a/app/api/etl.py
+++ b/app/api/etl.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 from datetime import datetime
 import os
 
-from fastapi import APIRouter, Form, Query
+from fastapi import APIRouter, Form, Query, Depends
 from fastapi.responses import HTMLResponse, JSONResponse
 
 from app.storage import blob, audit
+from app.auth.token import require_token
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(require_token)])
 
 HTML_TEMPLATE = (
     "<html><body>"

--- a/app/api/export.py
+++ b/app/api/export.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 from tempfile import NamedTemporaryFile
 from pathlib import Path
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, Depends
 from fastapi.responses import JSONResponse, PlainTextResponse, FileResponse
 
 from app.storage.db import SessionLocal, init_db
 from app.storage import models
+from app.auth.token import require_token
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(require_token)])
 
 
 def _records_to_markdown(labs, visits, structured) -> str:

--- a/app/api/rag.py
+++ b/app/api/rag.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
 from app.utils import chat_completion
+from app.auth.token import require_token
 
 
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(require_token)])
 
 
 class QueryRequest(BaseModel):

--- a/app/api/status.py
+++ b/app/api/status.py
@@ -3,14 +3,15 @@ from __future__ import annotations
 import json
 from datetime import datetime
 from pathlib import Path
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, Depends
 from fastapi.responses import JSONResponse
 
 from app.storage import audit
 from app.storage.db import SessionLocal, init_db
 from app.storage import models
+from app.auth.token import require_token
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(require_token)])
 
 
 def _load_audit(session_key: str) -> list[dict]:

--- a/app/api/upload.py
+++ b/app/api/upload.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 from pathlib import Path
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Depends
 from fastapi.responses import FileResponse, JSONResponse, HTMLResponse
 
 from app.storage import blob
+from app.auth.token import require_token
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(require_token)])
 
 HTML_PATH = Path(__file__).resolve().parents[1] / "web" / "upload_form.html"
 

--- a/docs/custom_gpt_setup.md
+++ b/docs/custom_gpt_setup.md
@@ -56,6 +56,7 @@ https://ai-delivery-sandbox-production-d1a7.up.railway.app/openapi.json
    - `GET /summary`
    - `POST /process`
    - `POST /upload`
+   - Ensure the `Authorization: Bearer <token>` header is sent with each call.
 4. Save the action and enable it.
 
 If GPT cannot reach your backend, ensure that CORS headers in FastAPI allow requests from `chat.openai.com`.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -136,6 +136,7 @@
         "operationId": "serveUploadForm",
         "summary": "Return HTML form for uploading files",
         "tags": ["Upload"],
+        "security": [{"bearerAuth": []}],
         "responses": {
           "200": {"description": "HTML form page", "content": {"text/html": {}}}
           }
@@ -146,6 +147,7 @@
         "operationId": "confirmProcess",
         "summary": "Return confirmation form before running ETL",
         "tags": ["Process"],
+        "security": [{"bearerAuth": []}],
         "parameters": [
           {"name": "session_key", "in": "query", "required": true, "schema": {"type": "string"}}
         ],
@@ -157,6 +159,7 @@
         "operationId": "processFiles",
         "summary": "Run ETL on uploaded files",
         "tags": ["Process"],
+        "security": [{"bearerAuth": []}],
         "requestBody": {
           "content": {
             "application/x-www-form-urlencoded": {
@@ -177,6 +180,7 @@
         "operationId": "askQuestion",
         "summary": "Answer a health-related question",
         "tags": ["Query"],
+        "security": [{"bearerAuth": []}],
         "requestBody": {
           "content": {
             "application/json": {
@@ -194,6 +198,7 @@
         "operationId": "exportRecords",
         "summary": "Export structured records",
         "tags": ["Export"],
+        "security": [{"bearerAuth": []}],
         "parameters": [
           {"name": "session_key", "in": "query", "required": true, "schema": {"type": "string"}},
           {"name": "format", "in": "query", "required": false, "schema": {"type": "string", "enum": ["json", "markdown", "pdf"], "default": "json"}}
@@ -213,6 +218,7 @@
         "operationId": "getSummary",
         "summary": "Summarize uploaded and processed records",
         "tags": ["Summary"],
+        "security": [{"bearerAuth": []}],
         "parameters": [
           {"name": "session_key", "in": "query", "required": true, "schema": {"type": "string"}}
         ],

--- a/tests/test_audit_logging.py
+++ b/tests/test_audit_logging.py
@@ -24,6 +24,9 @@ def test_consent_endpoint(monkeypatch, tmp_path):
     log_file = tmp_path / "audit.json"
     monkeypatch.setenv("AUDIT_LOG", str(log_file))
     audit = importlib.reload(importlib.import_module("app.storage.audit"))
+    monkeypatch.setenv("DELEGATION_SECRET", "test")
+    from app.auth.token import create_token
+    token = create_token("user", "agent", "portal")
     consent = importlib.reload(importlib.import_module("app.api.consent"))
 
     from fastapi import FastAPI
@@ -38,7 +41,7 @@ def test_consent_endpoint(monkeypatch, tmp_path):
         "action": "scrape",
         "timestamp": "2023-01-01T00:00:00",
     }
-    resp = client.post("/consent", json=payload)
+    resp = client.post("/consent", json=payload, headers={"Authorization": f"Bearer {token}"})
     assert resp.status_code == 200
     assert resp.json() == {"status": "consent recorded"}
 


### PR DESCRIPTION
## Summary
- add `require_token` FastAPI dependency to validate bearer tokens
- secure API routers with the new dependency
- document authorization header requirement in OpenAPI spec and setup guide
- adjust tests to supply a valid token

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852c3d1eaac8326bb4a80c569a20a1e