### PR TITLE
Add session key endpoint

### DIFF
--- a/app/api/session.py
+++ b/app/api/session.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from app.utils import generate_session_key
+from app.auth.token import require_token
+
+router = APIRouter(dependencies=[Depends(require_token)])
+
+
+@router.get("/session")
+def new_session() -> dict[str, str]:
+    """Return a freshly generated session key."""
+    return {"session_key": generate_session_key()}

--- a/app/main.py
+++ b/app/main.py
@@ -7,6 +7,7 @@ from .api.upload import router as upload_router
 from .api.etl import router as etl_router
 from .api.status import router as status_router
 from .api.export import router as export_router
+from .api.session import router as session_router
 
 app = FastAPI()
 router = APIRouter()
@@ -15,6 +16,7 @@ router.include_router(upload_router)
 router.include_router(etl_router)
 router.include_router(status_router)
 router.include_router(export_router)
+router.include_router(session_router)
 app.include_router(router)
 
 

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -1,1 +1,2 @@
 from .llm import chat_completion
+from .session import generate_session_key

--- a/app/utils/session.py
+++ b/app/utils/session.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+
+def generate_session_key() -> str:
+    """Return a new random session identifier."""
+    return uuid4().hex

--- a/docs/custom_gpt_setup.md
+++ b/docs/custom_gpt_setup.md
@@ -22,10 +22,11 @@ Paste the following into the **Instructions** field:
 You are the MyHealth Copilot, a private assistant that empowers patients—not portals—to control their own records. Think of yourself as a friendly health concierge.
 
 Your job is to guide the user through these steps:
-1. **Collect** – Invite the user to open OpenAI Operator at https://operator.chatgpt.com/ with the prompt "Download my latest health files." Once they return, you call `/upload` to accept the files.
-2. **Process** – After confirming the upload, call `/process` to structure the documents.
-3. **Answer** – Use `/ask` to respond to questions about labs, visit notes, and other records.
-4. **Export** – When requested, call `/summary` or `/export` so the user can download or share their data.
+1. **Start** – Call `/session` to obtain a unique session key for this conversation.
+2. **Collect** – Invite the user to open OpenAI Operator at https://operator.chatgpt.com/ with the prompt "Download my latest health files." Once they return, you call `/upload` using the session key to accept the files.
+3. **Process** – After confirming the upload, call `/process` with the same key to structure the documents.
+4. **Answer** – Use `/ask` with the session key to respond to questions about labs, visit notes, and other records.
+5. **Export** – When requested, call `/summary` or `/export` so the user can download or share their data.
 
 Example conversation:
 User: "I’d like to check my newest results."
@@ -52,6 +53,7 @@ https://ai-delivery-sandbox-production-d1a7.up.railway.app/openapi.json
 ```
 
 3. Approve the following endpoints:
+   - `GET /session`
    - `POST /ask`
    - `GET /summary`
    - `POST /process`

--- a/project/docs/operator_guidance.md
+++ b/project/docs/operator_guidance.md
@@ -9,7 +9,7 @@ These notes explain how to use OpenAI Operator with the provided prompt template
 4. Prefer **PDF** downloads. Use HTML only if a PDF option is unavailable.
 5. Save files using the convention `portal_DATE_type.pdf` (for example `mychart_2024-05-01_visit.pdf`).
 6. After downloading, close the Operator tab or return to the Copilot chat to upload your file.
-7. You can check `/summary?session_key=YOUR_ID` to confirm what was uploaded. Duplicate files will be flagged automatically.
+7. First call `/session` to receive a session key. Use this key with `/upload`, `/process`, and `/summary` to manage your data.
 
 ### Troubleshooting
 - If you hit reCAPTCHA or Cloudflare blocks, save the page as HTML or print to PDF and upload it from `/upload`.

--- a/task_guides/phase3_tasks/task_303_railway_e2e_test.md
+++ b/task_guides/phase3_tasks/task_303_railway_e2e_test.md
@@ -17,51 +17,57 @@ https://ai-delivery-sandbox-production-d1a7.up.railway.app
 ## 🧪 Test Steps
 Adapted from `task_209_end_to_end_test_plan.md`
 
-### 1. File Collection
-- ✅ Save `.html` or `.pdf` file exported from a health portal
-- ✅ Inspect locally to confirm content integrity
+### 1. Start Session
+```bash
+curl https://ai-delivery-sandbox-production-d1a7.up.railway.app/session
+```
+Use the returned `session_key` for the following steps.
 
-### 2. Upload via Web Interface
+### 2. File Collection
+ - ✅ Save `.html` or `.pdf` file exported from a health portal
+ - ✅ Inspect locally to confirm content integrity
+
+### 3. Upload via Web Interface
 Open:
 ```
-https://ai-delivery-sandbox-production-d1a7.up.railway.app/upload?session=test_user&portal=strava
+https://ai-delivery-sandbox-production-d1a7.up.railway.app/upload?session=<key>&portal=strava
 ```
-- ✅ Drag and drop or select file to upload
-- ✅ Confirm success message "Uploaded <filename>"
-- ✅ Metadata is logged automatically
+ - ✅ Drag and drop or select file to upload
+ - ✅ Confirm success message "Uploaded <filename>"
+ - ✅ Metadata is logged automatically
 
-### 3. Trigger ETL via Railway
+### 4. Trigger ETL via Railway
 ```bash
-curl -X POST https://ai-delivery-sandbox-production-d1a7.up.railway.app/process -F session_key=test_user
+curl -X POST https://ai-delivery-sandbox-production-d1a7.up.railway.app/process -F session_key=<key>
 ```
 - ✅ Logs show extraction and DB insertion
 
-### 4. Ask Question
+### 5. Ask Question
 ```bash
 curl -X POST https://ai-delivery-sandbox-production-d1a7.up.railway.app/ask \
   -H "Content-Type: application/json" \
-  -d '{"query": "What are my latest test results?", "session_key": "test_user"}'
+  -d '{"query": "What are my latest test results?", "session_key": "<key>"}'
 ```
 - ✅ Response includes extracted record content
 
-### 5. Export Data via API
+### 6. Export Data via API
 Markdown:
 ```bash
-curl "https://ai-delivery-sandbox-production-d1a7.up.railway.app/export?session_key=test_user&format=markdown"
+curl "https://ai-delivery-sandbox-production-d1a7.up.railway.app/export?session_key=<key>&format=markdown"
 ```
 JSON:
 ```bash
-curl "https://ai-delivery-sandbox-production-d1a7.up.railway.app/export?session_key=test_user&format=json"
+curl "https://ai-delivery-sandbox-production-d1a7.up.railway.app/export?session_key=<key>&format=json"
 ```
 PDF:
 ```bash
-curl -o records.pdf "https://ai-delivery-sandbox-production-d1a7.up.railway.app/export?session_key=test_user&format=pdf"
+curl -o records.pdf "https://ai-delivery-sandbox-production-d1a7.up.railway.app/export?session_key=<key>&format=pdf"
 ```
 - ✅ Outputs match uploaded file and extracted data
 
-### 6. Check Status
+### 7. Check Status
 ```bash
-curl https://ai-delivery-sandbox-production-d1a7.up.railway.app/summary?session_key=test_user | jq
+curl https://ai-delivery-sandbox-production-d1a7.up.railway.app/summary?session_key=<key> | jq
 ```
 - ✅ Confirm structured counts, timestamps, and sources
 

--- a/task_guides/phase3_tasks/task_304_gpt_e2e_test.md
+++ b/task_guides/phase3_tasks/task_304_gpt_e2e_test.md
@@ -22,7 +22,8 @@ Hi, I want to understand my recent medical results.
 - ✅ GPT should respond with guidance to upload a file and provide a secure upload link (via `/upload/sas`)
 
 ### 2. Upload Flow
-- Use the GPT-uploaded link or `/upload?session=test_user&portal=strava`
+- Obtain a session key from `/session`.
+- Use the GPT-uploaded link or `/upload?session=<key>&portal=strava`
 - Upload `.html` or `.pdf` file
 - GPT should offer to process it next
 

--- a/task_guides/phase3_tasks/task_306_fix_upload_form.md
+++ b/task_guides/phase3_tasks/task_306_fix_upload_form.md
@@ -43,5 +43,6 @@ fetch(data.url, {
 
 ---
 
-Let Stewart know when fixed so he can re-test via:  
-`https://ai-delivery-sandbox-production-d1a7.up.railway.app/upload?session=test_user&portal=lifelabs`
+Let Stewart know when fixed so he can re-test via:
+1. Fetch a new key from `/session`.
+2. `https://ai-delivery-sandbox-production-d1a7.up.railway.app/upload?session=<key>&portal=lifelabs`

--- a/tests/test_session_api.py
+++ b/tests/test_session_api.py
@@ -1,0 +1,28 @@
+import importlib
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def setup_app(monkeypatch):
+    monkeypatch.setenv("DELEGATION_SECRET", "test")
+    token_module = importlib.import_module("app.auth.token")
+    token = token_module.create_token("user", "agent", "portal")
+
+    session_module = importlib.reload(importlib.import_module("app.api.session"))
+    app = FastAPI()
+    app.include_router(session_module.router)
+    client = TestClient(app)
+    return client, token
+
+
+def test_session_endpoint(monkeypatch):
+    client, token = setup_app(monkeypatch)
+    resp1 = client.get("/session", headers={"Authorization": f"Bearer {token}"})
+    resp2 = client.get("/session", headers={"Authorization": f"Bearer {token}"})
+    assert resp1.status_code == 200
+    assert resp2.status_code == 200
+    key1 = resp1.json().get("session_key")
+    key2 = resp2.json().get("session_key")
+    assert isinstance(key1, str) and len(key1) >= 32
+    assert key1 != key2


### PR DESCRIPTION
## Summary
- generate uuid4 session keys in `utils`
- expose new `/session` API route
- update docs for obtaining session keys via the endpoint
- include `/session` in E2E task docs
- test new session route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852c959b7c88326aee78419198a2d5f