### PR TITLE
Enhance blob ETL classification

### DIFF
--- a/task_guides/task_500_blob_fhir_etl.md
+++ b/task_guides/task_500_blob_fhir_etl.md
@@ -1,0 +1,6 @@
+# Task 500: Blob ETL FHIR Integration
+
+- extend `run_etl_from_blobs` to parse labs and visits, assign codes and FHIR JSON
+- update `structuring.py` insert helpers to store codes and FHIR resources
+- added unit test coverage verifying FHIR data for blob ETL
+- revised ETL to call an LLM for detecting labs and visits, coding them, and generating FHIR resources


### PR DESCRIPTION
## Summary
- refine blob ETL to classify text with an LLM instead of relying on file types
- insert lab and visit data based on LLM detection and add FHIR resources
- adjust tests for new detection flow

## Testing
- `pytest tests/test_blob_etl.py::test_run_etl_from_blobs -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852cc11eea08326a2062d2b6e777964