### PR TITLE
Add FHIR bundle export option

### DIFF
--- a/docs/custom_gpt_setup.md
+++ b/docs/custom_gpt_setup.md
@@ -38,7 +38,8 @@ POST /ask
 { "session_key": "<SESSION_ID>", "query": "<user question>" }
 5. Export
 – To generate downloadable records, call:
-GET /export?session_key=<SESSION_ID>&format=pdf|markdown|json
+GET /export?session_key=<SESSION_ID>&format=pdf|markdown|json|fhir
+The `fhir` format returns a Bundle of FHIR Observation and Encounter resources in JSON.
 6. Summary
 – To provide a structured overview, call:
 GET /summary?session_key=<SESSION_ID>

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -408,7 +408,8 @@
               "enum": [
                 "json",
                 "markdown",
-                "pdf"
+                "pdf",
+                "fhir"
               ],
               "default": "json"
             }


### PR DESCRIPTION
## Summary
- extend API and CLI export tools with `format=fhir`
- collect `FHIRResource` rows and produce Bundle JSON
- document new query parameter
- test FHIR export

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852e878b0c48326b2e1725dd4fb362b