### PR TITLE
Fix public /upload

### DIFF
--- a/app/api/upload.py
+++ b/app/api/upload.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 from pathlib import Path
 from fastapi import APIRouter, HTTPException, Query, Depends
+import re
 from fastapi.responses import FileResponse, JSONResponse, HTMLResponse
 
 from app.storage import blob
 from app.auth.token import require_token
 
-router = APIRouter(dependencies=[Depends(require_token)])
+router = APIRouter()
 
 HTML_PATH = Path(__file__).resolve().parents[1] / "web" / "upload_form.html"
 
@@ -19,7 +20,7 @@ def upload_form() -> HTMLResponse:
     return HTMLResponse(html)
 
 
-@router.get("/upload/sas")
+@router.get("/upload/sas", dependencies=[Depends(require_token)])
 def get_sas(session_key: str = Query(...), filename: str = Query(...)) -> JSONResponse:
     """Return a SAS URL for uploading ``filename``."""
     ext = filename.rsplit(".", 1)[-1].lower()
@@ -29,7 +30,19 @@ def get_sas(session_key: str = Query(...), filename: str = Query(...)) -> JSONRe
     return JSONResponse({"url": url})
 
 
-@router.post("/upload/log")
+@router.get("/upload/proxy_sas")
+def get_proxy_sas(session_key: str = Query(...), filename: str = Query(...)) -> JSONResponse:
+    """Public SAS generator restricted to safe filenames."""
+    if not re.fullmatch(r"[A-Za-z0-9_-]{3,64}", session_key or ""):
+        raise HTTPException(status_code=400, detail="Invalid session key")
+    ext = filename.rsplit(".", 1)[-1].lower()
+    if ext not in {"pdf", "html", "txt"}:
+        raise HTTPException(status_code=400, detail="Invalid file type")
+    url = blob.generate_upload_url(session_key, filename)
+    return JSONResponse({"url": url})
+
+
+@router.post("/upload/log", dependencies=[Depends(require_token)])
 def log_upload(session_key: str, portal: str = "", filename: str = "") -> JSONResponse:
     """Record upload metadata via audit log."""
     blob.record_upload(session_key, portal, filename)

--- a/app/web/upload_form.html
+++ b/app/web/upload_form.html
@@ -52,6 +52,10 @@ function getParam(name) {
   return url.searchParams.get(name);
 }
 
+function getToken() {
+  return getParam('token');
+}
+
 function uploadFile(file) {
   const line = file._line || document.createElement('li');
   line.textContent = `Uploading ${file.name}...`;
@@ -61,21 +65,26 @@ function uploadFile(file) {
   }
   const session = getParam('session');
   const portal = getParam('portal') || '';
+  const token = getToken();
   if (!session) {
     line.textContent = 'Missing session id';
     return;
   }
-  fetch(`/upload/sas?session_key=${encodeURIComponent(session)}&filename=${encodeURIComponent(file.name)}`)
+  const sasEndpoint = token ? '/upload/sas' : '/upload/proxy_sas';
+  const headers = token ? { 'Authorization': `Bearer ${token}` } : {};
+  fetch(`${sasEndpoint}?session_key=${encodeURIComponent(session)}&filename=${encodeURIComponent(file.name)}`, { headers })
     .then(res => res.json())
     .then(data => fetch(data.url, { method: 'PUT', body: file, headers: { 'x-ms-blob-type': 'BlockBlob' } }))
     .then(resp => {
       if (resp.ok) {
         line.textContent = `Uploaded ${file.name} \u2714`;
-        fetch('/upload/log', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ session_key: session, portal: portal, filename: file.name })
-        });
+        if (token) {
+          fetch('/upload/log', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+            body: JSON.stringify({ session_key: session, portal: portal, filename: file.name })
+          });
+        }
       } else {
         line.textContent = `Upload failed ${file.name}: ${resp.status}`;
       }

--- a/tests/test_upload_api.py
+++ b/tests/test_upload_api.py
@@ -1,0 +1,38 @@
+import importlib
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def setup_app(monkeypatch=None):
+    upload_module = importlib.reload(importlib.import_module("app.api.upload"))
+    app = FastAPI()
+    app.include_router(upload_module.router)
+    if monkeypatch:
+        monkeypatch.setattr(
+            upload_module.blob,
+            "generate_upload_url",
+            lambda s, f: f"https://blob/{s}/{f}",
+        )
+    client = TestClient(app)
+    return client
+
+
+def test_upload_form_public_access():
+    client = setup_app()
+    resp = client.get("/upload", params={"session": "sess"})
+    assert resp.status_code == 200
+    assert "Upload Files" in resp.text
+
+
+def test_proxy_sas_public(monkeypatch):
+    client = setup_app(monkeypatch)
+    resp = client.get("/upload/proxy_sas", params={"session_key": "sess", "filename": "test.pdf"})
+    assert resp.status_code == 200
+    assert resp.json()["url"] == "https://blob/sess/test.pdf"
+
+
+def test_sas_requires_auth(monkeypatch):
+    client = setup_app(monkeypatch)
+    resp = client.get("/upload/sas", params={"session_key": "sess", "filename": "a.pdf"})
+    assert resp.status_code == 422
+


### PR DESCRIPTION
## Summary
- make `/upload` publicly accessible without token
- add `/upload/proxy_sas` for anon uploads
- update HTML upload form to use proxy if token missing
- test anonymous SAS and auth requirement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68531ac5a13483268de253380983161d