### PR TITLE
Improve LLM clinical classification parsing

### DIFF
--- a/tests/test_clinical_classifier.py
+++ b/tests/test_clinical_classifier.py
@@ -1,0 +1,32 @@
+import importlib
+import logging
+
+
+def test_classify_clinical_type_strips_wrappers(monkeypatch, caplog):
+    import app.orchestrator as orch_module
+
+    importlib.reload(orch_module)
+
+    def fake_chat(_messages):
+        return '```json\n{"clinical_type": "Procedure"}\n```'
+
+    monkeypatch.setattr(orch_module, "chat_completion", fake_chat)
+    caplog.set_level(logging.INFO)
+    result = orch_module._classify_clinical_type("Check for infection")
+    assert result[0] == "Procedure"
+    assert "LLM clinical classification failed" not in caplog.text
+
+
+def test_classify_clinical_type_invalid_json_falls_back(monkeypatch, caplog):
+    import app.orchestrator as orch_module
+
+    importlib.reload(orch_module)
+
+    def fake_chat(_messages):
+        return "{'clinical_type': 'Condition',}"
+
+    monkeypatch.setattr(orch_module, "chat_completion", fake_chat)
+    caplog.set_level(logging.WARNING)
+    result = orch_module._classify_clinical_type("Patient has diabetes")
+    assert result[0] == "Condition"
+    assert "LLM clinical classification failed" in caplog.text


### PR DESCRIPTION
## Summary
- make `_classify_clinical_type` robust against malformed JSON
- warn and fall back to regex classification when LLM output can't be parsed
- test parsing of markdown-wrapped and malformed LLM responses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853239f2cc483268b1c43832627dae7