### PR TITLE
Implement async processing for /process endpoint

### DIFF
--- a/tests/test_process_api.py
+++ b/tests/test_process_api.py
@@ -64,8 +64,9 @@ def test_process_route(monkeypatch, tmp_path):
     )
     assert resp.status_code == 200
     body = resp.json()
-    assert body["status"] == "processing complete"
-    assert body["summary"] == "sum"
+    assert body["status"] == "processing"
+    assert body["session_key"] == "sess"
+    assert "check /summary" in body["message"]
     assert called["prefix"] == "sess"
 
     logs = json.loads(log_file.read_text())


### PR DESCRIPTION
## Summary
- run ETL jobs in a FastAPI BackgroundTask so POST `/process` returns immediately
- add processing message and session key to `/process` response
- adjust tests for new asynchronous behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853290658188326a34c1a630b26b425