### PR TITLE
Add detailed logging for API flows

### DIFF
--- a/app/rag/searcher.py
+++ b/app/rag/searcher.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import logging
 from typing import List, Dict
 
 import chromadb
@@ -10,6 +11,8 @@ from chromadb.utils.embedding_functions import OpenAIEmbeddingFunction
 
 from dotenv import load_dotenv
 load_dotenv()
+
+logger = logging.getLogger(__name__)
 
 _COLLECTION = "health_records"
 
@@ -29,6 +32,12 @@ _embed = OpenAIEmbeddingFunction(api_key=os.getenv("OPENAI_API_KEY"))
 
 def search_records(query: str, session_key: str, n_results: int = 5) -> List[Dict]:
     """Return top matching records for ``query`` within a session."""
+    logger.info(
+        "[rag.searcher] query '%s' n=%d session=%s",
+        query,
+        n_results,
+        session_key,
+    )
     client = _get_client()
     collection = client.get_or_create_collection(_COLLECTION, embedding_function=_embed)
 
@@ -47,4 +56,9 @@ def search_records(query: str, session_key: str, n_results: int = 5) -> List[Dic
         if isinstance(meta, dict):
             record.update(meta)
         records.append(record)
+    logger.info(
+        "[rag.searcher] found %d records for session %s",
+        len(records),
+        session_key,
+    )
     return records


### PR DESCRIPTION
## Summary
- log workflow details for blob ETL including Chroma indexing
- add request tracing in `/ask_vector`, `/summary`, `/export`, and `/process`
- report empty tables or export failures in logs
- add record count logs to Chroma indexer and searcher

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68536e9864988326be54cd6d4d8f1a92