### PR TITLE
Add vector-based RAG search

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ data/audit_log.json
 
 ## 🚀 Deployment
 See [`project/docs/railway_deployment_guide.md`](project/docs/railway_deployment_guide.md) for instructions to deploy the FastAPI backend and web client on Railway.
+For running the Chroma vector database separately, see [`project/docs/chroma_deployment_guide.md`](project/docs/chroma_deployment_guide.md).
 
 ---
 

--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -548,7 +548,12 @@ def run_etl_from_blobs(prefix: str, user_id: str | None = None) -> str:
                 len(final_records),
                 prefix,
             )
-            insert_structured_records(session, final_records, session_key=prefix)
+            saved_records = insert_structured_records(session, final_records, session_key=prefix)
+            try:
+                from app.rag.indexer import index_structured_records
+                index_structured_records(saved_records, prefix)
+            except Exception as exc:  # noqa: BLE001
+                logger.error("[etl] Vector index failed: %s", exc)
 
         # detect labs and visits from structured records
         labs, visits = _detect_labs_and_visits_with_llm(final_records)

--- a/app/rag/indexer.py
+++ b/app/rag/indexer.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import os
+from typing import Iterable, List
+
+import chromadb
+from chromadb.api import ClientAPI
+from chromadb.api.types import Documents, Embeddings, IDs, Metadatas
+from chromadb.config import Settings
+from chromadb.utils.embedding_functions import OpenAIEmbeddingFunction
+
+
+_COLLECTION = "health_records"
+
+
+def _get_client() -> ClientAPI:
+    """Return a Chroma client based on environment settings."""
+    if os.getenv("USE_REMOTE_CHROMA", "false").lower() == "true":
+        host = os.getenv("CHROMA_SERVER_HOST", "localhost")
+        port = int(os.getenv("CHROMA_SERVER_HTTP_PORT", "8000"))
+        token = os.getenv("CHROMA_TOKEN")
+        headers = {"Authorization": f"Bearer {token}"} if token else None
+        return chromadb.HttpClient(host=host, port=port, headers=headers)
+    return chromadb.Client(Settings(allow_reset=True))
+
+
+_embed = OpenAIEmbeddingFunction()
+
+
+def _chunk(text: str, size: int = 500) -> List[str]:
+    return [text[i : i + size] for i in range(0, len(text), size)]
+
+
+def index_structured_records(records: Iterable, session_key: str) -> None:
+    """Index structured record objects for a session."""
+    client = _get_client()
+    collection = client.get_or_create_collection(_COLLECTION, embedding_function=_embed)
+
+    ids: List[str] = []
+    docs: Documents = []
+    metas: Metadatas = []
+
+    for rec in records:
+        text = getattr(rec, "text", "")
+        for i, chunk in enumerate(_chunk(text)):
+            ids.append(f"{session_key}_{rec.id}_{i}")
+            docs.append(chunk)
+            meta = {
+                "session_key": session_key,
+                "type": getattr(rec, "clinical_type", None) or getattr(rec, "type", None) or "",
+                "code": getattr(rec, "code", None) or "",
+                "date": str(getattr(rec, "date", "")) or "",
+            }
+            metas.append(meta)
+
+    if docs:
+        collection.add(documents=docs, ids=ids, metadatas=metas)

--- a/app/rag/searcher.py
+++ b/app/rag/searcher.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import os
+from typing import List, Dict
+
+import chromadb
+from chromadb.api import ClientAPI
+from chromadb.config import Settings
+from chromadb.utils.embedding_functions import OpenAIEmbeddingFunction
+
+_COLLECTION = "health_records"
+
+
+def _get_client() -> ClientAPI:
+    if os.getenv("USE_REMOTE_CHROMA", "false").lower() == "true":
+        host = os.getenv("CHROMA_SERVER_HOST", "localhost")
+        port = int(os.getenv("CHROMA_SERVER_HTTP_PORT", "8000"))
+        token = os.getenv("CHROMA_TOKEN")
+        headers = {"Authorization": f"Bearer {token}"} if token else None
+        return chromadb.HttpClient(host=host, port=port, headers=headers)
+    return chromadb.Client(Settings(allow_reset=True))
+
+
+_embed = OpenAIEmbeddingFunction()
+
+
+def search_records(query: str, session_key: str, n_results: int = 5) -> List[Dict]:
+    """Return top matching records for ``query`` within a session."""
+    client = _get_client()
+    collection = client.get_or_create_collection(_COLLECTION, embedding_function=_embed)
+
+    results = collection.query(
+        query_texts=[query],
+        n_results=n_results,
+        where={"session_key": session_key},
+    )
+
+    docs = results.get("documents", [[]])[0]
+    metas = results.get("metadatas", [[]])[0]
+
+    records: List[Dict] = []
+    for doc, meta in zip(docs, metas):
+        record = {"text": doc}
+        if isinstance(meta, dict):
+            record.update(meta)
+        records.append(record)
+    return records

--- a/app/storage/structured.py
+++ b/app/storage/structured.py
@@ -7,7 +7,7 @@ from .models import StructuredRecord, FHIRResource
 
 def insert_structured_records(
     session: Session, records: list[dict], session_key: str | None = None
-) -> None:
+) -> list[StructuredRecord]:
     """Insert cleaned AI-extracted records."""
     objs = []
     existing = {
@@ -33,6 +33,7 @@ def insert_structured_records(
     if objs:
         session.add_all(objs)
         session.commit()
+    return objs
 
 
 def insert_fhir_resources(session: Session, resources: list[dict]) -> None:

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -376,6 +376,57 @@
         }
       }
     },
+    "/ask_vector": {
+      "post": {
+        "operationId": "askQuestionVector",
+        "summary": "Answer a health-related question using vector search",
+        "tags": [
+          "Query"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "query": {
+                    "type": "string"
+                  },
+                  "session_key": {
+                    "type": "string"
+                  },
+                  "top_k": {
+                    "type": "integer",
+                    "default": 5
+                  }
+                },
+                "required": [
+                  "query",
+                  "session_key"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Answer text",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Answer"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/export": {
       "get": {
         "operationId": "exportRecords",

--- a/project/docs/chroma_deployment_guide.md
+++ b/project/docs/chroma_deployment_guide.md
@@ -1,0 +1,28 @@
+# Chroma Vector Store Deployment
+
+This guide describes how to host a ChromaDB instance on Railway and connect it to the FastAPI server.
+
+## Deploy Chroma
+1. Create a new Railway project.
+2. Add the provided `Dockerfile` and `docker-compose.yaml` from this repo.
+3. Expose port `8000` in the service.
+4. Set environment variables:
+   ```env
+   CHROMA_HTTP_PORT=8000
+   CHROMA_SERVER_AUTH_TOKEN=<secure_token>
+   ```
+   Generate a random UUID for `<secure_token>` and store it in Railway secrets.
+
+## Configure FastAPI Server
+In the AI Copilot project, set:
+```env
+USE_REMOTE_CHROMA=true
+CHROMA_SERVER_HOST=https://<your-chroma-subdomain>.up.railway.app
+CHROMA_TOKEN=<secure_token>
+```
+The host value comes from the Railway URL after deploying Chroma. Use the same token value as above.
+
+## Verify Connectivity
+1. Upload health records and run the ETL pipeline so they are indexed.
+2. Call `/ask_vector` with a question. If records were indexed, the answer should reference the retrieved context.
+3. Ensure results only include records for the current `session_key`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,5 @@ markdown2
 reportlab
 azure-storage-blob==12.19.0
 pyodbc
+chromadb
 

--- a/tests/test_clinical_classifier.py
+++ b/tests/test_clinical_classifier.py
@@ -3,6 +3,7 @@ import logging
 
 
 def test_classify_clinical_type_strips_wrappers(monkeypatch, caplog):
+    monkeypatch.setenv("FERNET_KEY", "test-key")
     import app.orchestrator as orch_module
 
     importlib.reload(orch_module)
@@ -18,6 +19,7 @@ def test_classify_clinical_type_strips_wrappers(monkeypatch, caplog):
 
 
 def test_classify_clinical_type_invalid_json_falls_back(monkeypatch, caplog):
+    monkeypatch.setenv("FERNET_KEY", "test-key")
     import app.orchestrator as orch_module
 
     importlib.reload(orch_module)

--- a/tests/test_rag_vector_api.py
+++ b/tests/test_rag_vector_api.py
@@ -1,0 +1,44 @@
+import importlib
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from fastapi.testclient import TestClient
+
+
+def setup_app(monkeypatch):
+    monkeypatch.setenv("DELEGATION_SECRET", "test")
+    monkeypatch.setenv("CHROMA_OPENAI_API_KEY", "sk-test")
+    from app.auth.token import create_token
+    token = create_token("user", "agent", "portal")
+
+    def fake_search(query, session_key, n_results=5):
+        return [{"text": "Record 1"}, {"text": "Record 2"}]
+
+    def fake_chat(messages, **_kwargs):
+        content = messages[0]["content"]
+        assert "Record 1" in content
+        return "Vector answer"
+
+    import app.rag.searcher as search_module
+    monkeypatch.setattr(search_module, "search_records", fake_search)
+    import app.api.rag as rag_module
+    monkeypatch.setattr(rag_module, "chat_completion", fake_chat)
+
+    import app.main as main_module
+    main_module = importlib.reload(main_module)
+    return TestClient(main_module.app), token
+
+
+def test_ask_vector(monkeypatch):
+    client, token = setup_app(monkeypatch)
+    resp = client.post(
+        "/ask_vector",
+        json={"query": "test", "session_key": "sess"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"answer": "Vector answer"}


### PR DESCRIPTION
## Summary
- integrate Chroma vector store with simple indexer and searcher
- support `/ask_vector` FastAPI route for semantic retrieval
- add Chroma dependency and indexing call in ETL
- document Chroma deployment and update OpenAPI spec
- sanitize metadata before indexing into Chroma

## Testing
- `pip install -r requirements.txt`
- `playwright install`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68535c9e17bc832693235cdaf2d93c05