### PR TITLE
Add demo mode with sample PDFs

### DIFF
--- a/app/api/demo.py
+++ b/app/api/demo.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import random
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import JSONResponse
+
+from app.utils import generate_session_key
+from app.storage import blob
+from app.auth.token import require_token
+
+router = APIRouter(dependencies=[Depends(require_token)])
+
+@router.post("/load_demo")
+def load_demo() -> JSONResponse:
+    """Load a sample health record from blob storage and run ETL."""
+    try:
+        demo_blobs = blob.list_demo_blob_files("demo/")
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=500, detail="Demo storage not available") from exc
+    if not demo_blobs:
+        raise HTTPException(status_code=500, detail="No demo data available")
+
+    blob_name = random.choice(demo_blobs)
+    filename = Path(blob_name).name
+    data = blob.download_blob(blob_name)
+
+    session_key = generate_session_key()
+    dest_name = f"{session_key}/{filename}"
+    url = blob.upload_file_and_get_url(
+        data, dest_name, content_type="application/pdf"
+    )
+    blob.record_upload(session_key, "demo", filename)
+    from app.orchestrator import run_etl_from_blobs
+
+    run_etl_from_blobs(session_key)
+
+    return JSONResponse(
+        {"session_key": session_key, "source": filename, "source_url": url}
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -8,6 +8,7 @@ from .api.etl import router as etl_router
 from .api.status import router as status_router
 from .api.export import router as export_router
 from .api.session import router as session_router
+from .api.demo import router as demo_router
 
 app = FastAPI()
 router = APIRouter()
@@ -17,6 +18,7 @@ router.include_router(etl_router)
 router.include_router(status_router)
 router.include_router(export_router)
 router.include_router(session_router)
+router.include_router(demo_router)
 app.include_router(router)
 
 

--- a/app/storage/blob.py
+++ b/app/storage/blob.py
@@ -106,6 +106,11 @@ def list_blob_info(prefix: str) -> list[dict[str, object]]:
     return info
 
 
+def list_demo_blob_files(prefix: str = "demo/") -> list[str]:
+    """Return demo blob filenames using ``prefix``."""
+    return list_blobs(prefix)
+
+
 def download_blob(name: str) -> bytes:
     """Return contents of blob ``name``."""
     if not _container:

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -231,7 +231,17 @@
           }
         }
       }
+    },
+    "DemoLoadResponse": {
+      "type": "object",
+      "properties": {
+        "session_key": {"type": "string"},
+        "source": {"type": "string"},
+        "source_url": {"type": "string", "format": "uri"}
+      },
+      "required": ["session_key", "source", "source_url"]
     }
+  }
   },
   "paths": {
     "/upload": {
@@ -490,6 +500,32 @@
                   "required": [
                     "session_key"
                   ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/load_demo": {
+      "post": {
+        "operationId": "loadDemoData",
+        "summary": "Load a sample health record for testing",
+        "tags": [
+          "Demo"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Demo data session information",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DemoLoadResponse"
                 }
               }
             }

--- a/project/demo_data/er_note.pdf
+++ b/project/demo_data/er_note.pdf
@@ -1,0 +1,68 @@
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 7 0 R /MediaBox [ 0 0 612 792 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250619185017+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250619185017+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 185
+>>
+stream
+Gap@F5mkI_'L_\e@[8LNk,/C!V-%`r6KDJr`7.92Ua0<[^/8EqJU%Y45o%d#m0)bnRj3J@\-KEa$U1?G7H*m2DKW2c:KX2tT"UL'h%_)j6_E?@X`RL@VBWFc`JA_(+NYL@2tSgJccPrYM@%VVeN!>?#F"S0]Y+`Xkp:Ll\R'h/i:ZgdM[s5a0:W~>endstream
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000000404 00000 n 
+0000000472 00000 n 
+0000000768 00000 n 
+0000000827 00000 n 
+trailer
+<<
+/ID 
+[<3da026d9977ce2f2a9c9a38343a2f033><3da026d9977ce2f2a9c9a38343a2f033>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
+startxref
+1102
+%%EOF

--- a/project/demo_data/family_doctor_visit.pdf
+++ b/project/demo_data/family_doctor_visit.pdf
@@ -1,0 +1,68 @@
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 7 0 R /MediaBox [ 0 0 612 792 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250619185017+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250619185017+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 185
+>>
+stream
+Gap@F5mkI_'L_[Y`@P#&rJ;9*SUt.Xki,sBVQp,`1m1>UgD`RnR)NQi;4oK59B1RJA)/O]%DG0Z<=M.P`'rhR?ess_!dcJecAR%E%jm!dVp(;8->:hsP'![;O1%\jVhAaP+f6-&d)1OWE3%>T4.@W7gZ.5098khX'=L;XW0Z?R]_\4pp]0KS/jo~>endstream
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000000404 00000 n 
+0000000472 00000 n 
+0000000768 00000 n 
+0000000827 00000 n 
+trailer
+<<
+/ID 
+[<9525d51809f3edb47b58b3c66d696608><9525d51809f3edb47b58b3c66d696608>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
+startxref
+1102
+%%EOF

--- a/project/demo_data/lab_results.pdf
+++ b/project/demo_data/lab_results.pdf
@@ -1,0 +1,68 @@
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 7 0 R /MediaBox [ 0 0 612 792 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250619185017+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250619185017+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 161
+>>
+stream
+Gap@F_$\%5&4H!cME.]hA2gA6*YlX]Nr&oZ@]Lb,2"gm.+u@I%1!D>MMLTop^d2AS%!I^ofGb>-3([%/s/T@*9ot<&\Fu;!H)J3gOk[8(>OM3p`2l>Srpd!-KY`C#Nh`IRju@'AB6M@!P7;+1GsYQh%l>@\R3P]~>endstream
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000000404 00000 n 
+0000000472 00000 n 
+0000000768 00000 n 
+0000000827 00000 n 
+trailer
+<<
+/ID 
+[<2c64fb8815b51c3931dcd79da380ce25><2c64fb8815b51c3931dcd79da380ce25>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
+startxref
+1078
+%%EOF

--- a/project/demo_data/pharmacy_list.pdf
+++ b/project/demo_data/pharmacy_list.pdf
@@ -1,0 +1,68 @@
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 7 0 R /MediaBox [ 0 0 612 792 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250619185017+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250619185017+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 165
+>>
+stream
+Gap@F9+&O$&4H7Q74hLb:5=Y`:*m(&XtL@H6p&U?F=-a+r(rGX4:6sREp28k#L8:aPs?(/!7bWiDUEEc4oM:6.V$78X375P6\;cXl+82qbX^H))PVNafGaqmgnL':6C_!pk\!ZY^*Kc,6,K[D<m*@F"E-J2.,H0i.6d~>endstream
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000000404 00000 n 
+0000000472 00000 n 
+0000000768 00000 n 
+0000000827 00000 n 
+trailer
+<<
+/ID 
+[<ab9a52a7d9e6a250afca9caab0912fe9><ab9a52a7d9e6a250afca9caab0912fe9>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
+startxref
+1082
+%%EOF

--- a/project/demo_data/physio_summary.pdf
+++ b/project/demo_data/physio_summary.pdf
@@ -1,0 +1,68 @@
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 7 0 R /MediaBox [ 0 0 612 792 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250619185017+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250619185017+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 187
+>>
+stream
+Gap@G5mkI_'L_[Y`@P#&:"$'";ULa;OahpqJ"*IQ.7k8#H_\XjZZs.%BW)XDgRA1)_XaY!%B+i\M@+IBJ[35e?eq)K"VT&)DMju,*="Z"LbB>Z-5^=:>cmQpD6`gj4F-!+CIF3)mNWVlnE?8Pf\(%kMsX`'D]jL&!]h3NIreo>6$L]8HN;_(fI\dg~>endstream
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000000404 00000 n 
+0000000472 00000 n 
+0000000768 00000 n 
+0000000827 00000 n 
+trailer
+<<
+/ID 
+[<840f65d854ad74c9423f8b6954e077cc><840f65d854ad74c9423f8b6954e077cc>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
+startxref
+1104
+%%EOF

--- a/project/docs/prompt_starter_kit.md
+++ b/project/docs/prompt_starter_kit.md
@@ -40,3 +40,26 @@ Use these sample prompts to explore your records once you have uploaded them thr
 - "Generate a PDF summary for my next appointment."
 - "Prepare a file I can share with my doctor."
 - "List questions I should ask at my visit."
+
+## Demo Record Questions
+When using the `/load_demo` endpoint, try these prompts for each sample case:
+
+### Family Doctor Visit
+- "What medication was prescribed at the demo visit?"
+- "Summarize why the patient saw the doctor on 2023-02-20."
+
+### Hospital ER Note
+- "What treatment was provided in the ER?"
+- "Were any discharge instructions given?"
+
+### Lab Results
+- "List the demo lab values."
+- "Is the cholesterol result normal?"
+
+### Pharmacy List
+- "Which medications are listed in the sample file?"
+- "Why might someone take Metformin?"
+
+### Physio Summary
+- "How many physio sessions were recorded?"
+- "What improvements were noted in the summary?"

--- a/tests/test_demo_api.py
+++ b/tests/test_demo_api.py
@@ -1,0 +1,57 @@
+import importlib
+import sys
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def setup_app(monkeypatch):
+    monkeypatch.setenv("DELEGATION_SECRET", "test")
+    from cryptography.fernet import Fernet
+    monkeypatch.setenv("FERNET_KEY", Fernet.generate_key().decode())
+    from app.auth.token import create_token
+    token = create_token("user", "agent", "portal")
+
+    demo_module = importlib.reload(importlib.import_module("app.api.demo"))
+
+    sample = next((ROOT / "project" / "demo_data").glob("*.pdf"))
+    monkeypatch.setattr(
+        demo_module.blob,
+        "list_demo_blob_files",
+        lambda prefix="demo/": [f"demo/{sample.name}"]
+    )
+    monkeypatch.setattr(demo_module.blob, "download_blob", lambda name: sample.read_bytes())
+    monkeypatch.setattr(
+        demo_module.blob,
+        "upload_file_and_get_url",
+        lambda data, name, **k: f"https://blob/{name}",
+    )
+    called = {}
+    import app.orchestrator as orch_module
+    monkeypatch.setattr(
+        orch_module,
+        "run_etl_from_blobs",
+        lambda prefix: called.setdefault("prefix", prefix),
+    )
+    monkeypatch.setattr(demo_module, "generate_session_key", lambda: "sess")
+
+    app = FastAPI()
+    app.include_router(demo_module.router)
+    client = TestClient(app)
+    return client, token, called, sample.name
+
+
+def test_load_demo(monkeypatch):
+    client, token, called, filename = setup_app(monkeypatch)
+    resp = client.post("/load_demo", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["session_key"] == "sess"
+    assert body["source"] == filename
+    assert body["source_url"].startswith("https://blob/sess/")
+    assert called["prefix"] == "sess"


### PR DESCRIPTION
## Summary
- provide `/load_demo` route for quickly loading sample records
- include five demo PDF files
- document demo prompts in the starter kit
- expand OpenAPI schema for `/load_demo`
- test the new route
- fetch demo PDFs from blob storage instead of local disk

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68545b516fa483269bd0b7a02c949499