### PR TITLE
Add user access guidance for new AI Assistant users

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ data/audit_log.json
 - `scripts/` – test runners, dev helpers
 - `task_guides/` – Codex tasks + reviews
 - `project/docs/` – design docs
+- See [`project/docs/user_access_guidance.md`](project/docs/user_access_guidance.md) for who can use Operator and how to test the assistant.
 
 ---
 

--- a/comms/blog_post.md
+++ b/comms/blog_post.md
@@ -110,6 +110,7 @@ The difference this time was using OpenAI Codex Agents, which handled 135 develo
 
 What Comes Next
 The MyHealth AI Assistant is live! If you'd like to try it and share feedback, please send a message to the authors. Caveat emptor—this is an early proof of concept (PoC) and rough around the edges. Operator is still in preview and requires a Pro license, but the rest of the Assistant is available with a Plus subscription.
+See the [User Access Guidance](../project/docs/user_access_guidance.md) for how to experiment safely with or without Operator.
 
 Natural next steps include exploring policy and regulatory engagement, piloting use cases, and expanding applications in the public sector. These efforts will help shape the future of the system and ensure broader adoption and alignment with industry standards.
 

--- a/project/docs/user_access_guidance.md
+++ b/project/docs/user_access_guidance.md
@@ -1,0 +1,33 @@
+# User Access & Usage Guidance
+
+This guide explains how to try the AI Health Records Assistant safely.
+It covers who can use the assistant, when to rely on OpenAI Operator, and
+how to test features without sharing personal information.
+
+## Who Can Use the Assistant?
+- **ChatGPT Pro users** have full access, including the Operator tool for
+  navigating portals.
+- **Plus and free-tier users** can still chat with the assistant and upload
+  files, but Operator is unavailable.
+
+## When to Use Operator
+- Use Operator when retrieving records from **your own health portals**.
+  It keeps the browser session private and lets you confirm each step.
+- For testing or demo flows, Operator is **not required**. You can upload
+  sample files or use the `/load_demo` endpoint to load mock records.
+
+## What Works Without Pro
+- Upload mock PDFs from `project/demo_data` or your own test files.
+- Ask questions about these demo sessions using `/ask_vector` or `/summary`.
+- Export structured content and review logs even without Operator.
+
+## Best Practices for Real Portals
+- Only use portals you personally have access to.
+- Review your portal's terms of use before automating downloads.
+- Keep downloads secure and delete them when finished.
+- Remember the assistant is a **proof of concept** and may contain bugs.
+
+## Disclaimer
+See [disclaimer.md](disclaimer.md) for important limitations. The
+assistant is not a medical device or clinical decision tool.
+Use it at your own risk and verify all outputs.


### PR DESCRIPTION
## Summary
- document how users can test the AI Assistant with or without OpenAI Operator
- link the new guide from README and blog post

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685463cea7b88326986daa562e00cc83