### PR TITLE
Improve vector prompt for small record sets

### DIFF
--- a/app/api/demo.py
+++ b/app/api/demo.py
@@ -36,6 +36,4 @@ def load_demo() -> JSONResponse:
 
     run_etl_from_blobs(session_key)
 
-    return JSONResponse(
-        {"session_key": session_key, "source": filename}
-    )
+    return JSONResponse({"session_key": session_key, "source": filename, "source_url": url})

--- a/app/rag/indexer.py
+++ b/app/rag/indexer.py
@@ -53,8 +53,13 @@ def index_structured_records(records: Iterable, session_key: str) -> None:
             docs.append(chunk)
             meta = {
                 "session_key": session_key,
-                "type": getattr(rec, "clinical_type", None) or getattr(rec, "type", None) or "",
+                "type": getattr(rec, "clinical_type", None)
+                or getattr(rec, "type", None)
+                or "",
                 "code": getattr(rec, "code", None) or "",
+                "display": getattr(rec, "display", None) or "",
+                "source_url": getattr(rec, "source_url", None) or "",
+                "portal": getattr(rec, "portal", None) or "",
                 "date": str(getattr(rec, "date", "")),
             }
             metas.append({k: v for k, v in meta.items() if v is not None})

--- a/app/utils/sample_files.py
+++ b/app/utils/sample_files.py
@@ -5,13 +5,15 @@ from pathlib import Path
 
 
 def create_sample_pdf(path: Path) -> None:
-    """Create a simple PDF with two lab result lines."""
+    """Create a simple PDF with a few example records."""
     import fitz  # PyMuPDF
 
     doc = fitz.open()
     page = doc.new_page()
     page.insert_text((72, 72), "Cholesterol 5.8 mmol/L 2023-05-01")
     page.insert_text((72, 90), "Hemoglobin 13.5 g/dL 2023-05-02")
+    page.insert_text((72, 108), "Patient treated for sprained ankle in ER on March 10")
+    page.insert_text((72, 126), "Procedure 6142004 performed; discharged with crutches")
     doc.save(path)
     doc.close()
 

--- a/tests/test_rag_vector_api.py
+++ b/tests/test_rag_vector_api.py
@@ -16,11 +16,16 @@ def setup_app(monkeypatch):
     token = create_token("user", "agent", "portal")
 
     def fake_search(query, session_key, n_results=5):
-        return [{"text": "Record 1"}, {"text": "Record 2"}]
+        return [
+            {"text": "Patient treated for sprained ankle", "type": "Procedure", "code": "6142004"},
+            {"text": "Discharged with crutches"},
+        ]
 
     def fake_chat(messages, **_kwargs):
         content = messages[0]["content"]
-        assert "Record 1" in content
+        assert "Record 1:" in content
+        assert "Type: Procedure" in content
+        assert "Code: 6142004" in content
         return "Vector answer"
 
     import app.rag.searcher as search_module


### PR DESCRIPTION
## Summary
- expand Chroma metadata indexing to include `display`, `source_url`, and `portal`
- enrich `/ask_vector` prompt with structured fields per record
- expose `source_url` in `/load_demo`
- enhance sample PDF content for demos
- update vector API test for new prompt format

## Testing
- `pip install -r requirements.txt`
- `playwright install` *(failed: missing dependencies)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855476875ac8326b4676bca3d6cc1c8