### PR TITLE
Add demo-only GPT setup

### DIFF
--- a/project/demo_mode/demo_gpt_setup.md
+++ b/project/demo_mode/demo_gpt_setup.md
@@ -1,0 +1,85 @@
+# Setup Guide: MyHealth Assistant – Demo Mode
+
+This walkthrough explains how to set up a demo-only version of the MyHealth Assistant GPT. It loads sample data but does not upload or process any real records.
+
+---
+
+## 1. Create the GPT
+1. Go to <https://platform.openai.com/gpts> and select **Create New GPT**.
+2. Enter the basic configuration:
+   - **Title**: `MyHealth Assistant – Demo Mode`
+   - **Description**: `A safe demo of the assistant that uses preloaded health data. Real uploads and sessions are disabled.`
+   - **Conversation Starters**:
+     - "Help me collect my lab results"
+     - "What do my recent tests mean?"
+     - "Summarize my last hospital visit"
+     - "Export everything so I can share with my doctor"
+
+## 2. System Instructions
+Paste the following into the **Instructions** field:
+
+```text
+You are the MyHealth Assistant – Demo Mode, a private assistant that empowers patients—not portals—to control their own records. Think of yourself as a friendly health concierge.
+
+Your job is to guide the user through these steps:
+1. **Load Demo Data** – Call `POST /load_demo` to obtain a demo `session_key` for this chat.
+2. **Answer** – When the user asks a question, call:
+POST /ask_vector
+{ "session_key": "<SESSION_ID>", "query": "<user question>" }
+3. **Export** – To download the demo records, call:
+GET /export?session_key=<SESSION_ID>&format=pdf|markdown|json|fhir
+4. **Summary** – Provide an overview with:
+GET /summary?session_key=<SESSION_ID>
+
+Example conversation:
+User: "Show me a demo."
+Assistant: *(calls `/load_demo`)* "I've loaded a sample record. Ask me anything."
+User: "What are the latest labs?"
+Assistant: *(calls `/ask_vector`)* "The demo A1C is 6.8." "Would you like a summary or export?"
+
+Rules:
+- Always obtain user consent before processing.
+- Never diagnose or replace medical professionals.
+- Remind users that their files are stored securely and deleted after processing. Encryption and patient-controlled access keep their data private.
+
+Tone: Supportive, clear and privacy‑conscious.
+```
+
+## 3. Add API Actions
+1. In the **Actions** tab choose **Create New Action**.
+2. Provide your FastAPI OpenAPI schema URL:
+
+```
+https://ai-delivery-sandbox-production-d1a7.up.railway.app/openapi.json
+```
+
+3. Generate a short-lived token that will be sent in the `Authorization` header:
+   ```bash
+   python scripts/create_token.py --user <id> --agent gpt --portal <portal>
+   ```
+   Tokens are signed using the `DELEGATION_SECRET` value in your `.env` file.
+   They expire after the `--minutes` provided (default `10`). Regenerate and
+   update the GPT action whenever a token expires.
+4. Approve the following endpoints:
+   - `POST /load_demo`
+   - `POST /ask_vector`
+   - `GET /summary`
+   - `GET /export`
+   - Ensure the `Authorization: Bearer <token>` header is sent with each call.
+   Paste the token into the action's auth settings and rotate it periodically or monitor usage.
+5. Save the action and enable it.
+
+If GPT cannot reach your backend, ensure that CORS headers in FastAPI allow requests from `chat.openai.com`.
+
+## 4. Test the Assistant
+- Start a chat and say **"Show me the demo"**.
+- The GPT should call `/load_demo` automatically.
+- Ask follow-up questions to trigger `/ask_vector`.
+- Verify that `/summary` and `/export` return demo data.
+
+---
+
+## ✅ Completion Criteria
+- The GPT loads demo data using `/load_demo`.
+- `/ask_vector`, `/summary`, and `/export` return responses.
+- No upload or session endpoints are called.

--- a/project/demo_mode/demo_openapi.json
+++ b/project/demo_mode/demo_openapi.json
@@ -1,0 +1,415 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "MyHealth Copilot API",
+    "version": "1.0.0",
+    "description": "Endpoints used by the MyHealth Copilot GPT to process and answer questions about health records"
+  },
+  "servers": [
+    {
+      "url": "https://ai-delivery-sandbox-production-d1a7.up.railway.app",
+      "description": "Production server"
+    }
+  ],
+  "security": [
+    {
+      "bearerAuth": []
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    },
+    "schemas": {
+      "ProcessStatus": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
+      "Answer": {
+        "type": "object",
+        "properties": {
+          "answer": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "answer"
+        ]
+      },
+      "ExportData": {
+        "type": "object",
+        "properties": {
+          "lab_results": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "test_name": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "number"
+                },
+                "units": {
+                  "type": "string"
+                },
+                "date": {
+                  "type": "string",
+                  "format": "date"
+                }
+              },
+              "required": [
+                "test_name",
+                "value",
+                "units",
+                "date"
+              ]
+            }
+          },
+          "visit_summaries": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "provider": {
+                  "type": "string"
+                },
+                "doctor": {
+                  "type": "string"
+                },
+                "notes": {
+                  "type": "string"
+                },
+                "date": {
+                  "type": "string",
+                  "format": "date"
+                }
+              },
+              "required": [
+                "provider",
+                "doctor",
+                "notes",
+                "date"
+              ]
+            }
+          },
+          "structured_records": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "portal": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                },
+                "text": {
+                  "type": "string"
+                },
+                "source_url": {
+                  "type": "string"
+                },
+                "date_created": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              },
+              "required": [
+                "portal",
+                "type",
+                "text",
+                "date_created"
+              ]
+            }
+          }
+        }
+      },
+      "Summary": {
+        "type": "object",
+        "properties": {
+          "uploads": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "filename": {
+                  "type": "string"
+                },
+                "portal": {
+                  "type": "string"
+                },
+                "timestamp": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "record_counts": {
+            "type": "object",
+            "properties": {
+              "labs": {
+                "type": "integer"
+              },
+              "visits": {
+                "type": "integer"
+              },
+              "structured": {
+                "type": "integer"
+              }
+            }
+          },
+          "latest_upload": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "latest_processing": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "latest_record_dates": {
+            "type": "object",
+            "properties": {
+              "labs": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "visits": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "structured": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          },
+          "structured_records": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "portal": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                },
+                "source_url": {
+                  "type": "string"
+                },
+                "timestamp": {
+                  "type": "string"
+                },
+                "duplicate": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "DemoLoadResponse": {
+      "type": "object",
+      "properties": {
+        "session_key": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "session_key",
+        "source",
+        "source_url"
+      ]
+    }
+  },
+  "paths": {
+    "/ask_vector": {
+      "post": {
+        "operationId": "askQuestion",
+        "summary": "Answer a health-related question",
+        "tags": [
+          "Query"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "query": {
+                    "type": "string"
+                  },
+                  "session_key": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "query",
+                  "session_key"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Answer text",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Answer"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/export": {
+      "get": {
+        "operationId": "exportRecords",
+        "summary": "Export structured records",
+        "tags": [
+          "Export"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "session_key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "json",
+                "markdown",
+                "pdf",
+                "fhir"
+              ],
+              "default": "json"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Exported records",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExportData"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/summary": {
+      "get": {
+        "operationId": "getSummary",
+        "summary": "Summarize uploaded and processed records",
+        "tags": [
+          "Summary"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "session_key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Summary information",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Summary"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/load_demo": {
+      "post": {
+        "operationId": "loadDemoData",
+        "summary": "Load a sample health record for testing",
+        "tags": [
+          "Demo"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Demo data session information",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DemoLoadResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `demo_mode/` directory for demo-specific assets
- create simplified GPT setup instructions for demo mode
- create reduced OpenAPI schema exposing only demo endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68554c5fb7e48326aaf56f054df8a75c