### PR TITLE
Fix demo load URL

### DIFF
--- a/app/api/demo.py
+++ b/app/api/demo.py
@@ -28,12 +28,13 @@ def load_demo() -> JSONResponse:
 
     session_key = generate_session_key()
     dest_name = f"{session_key}/{filename}"
-    url = blob.upload_file_and_get_url(
+    blob.upload_file_and_get_url(
         data, dest_name, content_type="application/pdf"
     )
     blob.record_upload(session_key, "demo", filename)
+    source_url = blob.get_blob_url(blob_name)
     from app.orchestrator import run_etl_from_blobs
 
     run_etl_from_blobs(session_key)
 
-    return JSONResponse({"session_key": session_key, "source": filename, "source_url": url})
+    return JSONResponse({"session_key": session_key, "source": filename, "source_url": source_url})

--- a/app/storage/blob.py
+++ b/app/storage/blob.py
@@ -120,6 +120,23 @@ def download_blob(name: str) -> bytes:
     return stream.readall()
 
 
+def get_blob_url(blob_name: str, ttl_minutes: int = 30) -> str:
+    """Return a time-limited SAS URL for existing blob ``blob_name``."""
+    if not _container or not _account_key:
+        raise RuntimeError("Azure blob storage not configured")
+
+    client = _container.get_blob_client(blob_name)
+    sas = generate_blob_sas(
+        account_name=_account_name,
+        container_name=CONTAINER,
+        blob_name=blob_name,
+        account_key=_account_key,
+        permission=BlobSasPermissions(read=True),
+        expiry=datetime.utcnow() + timedelta(minutes=ttl_minutes),
+    )
+    return f"{client.url}?{sas}"
+
+
 def delete_blob(name: str) -> None:
     """Delete blob ``name`` if it exists."""
     if not _container:

--- a/tests/test_demo_api.py
+++ b/tests/test_demo_api.py
@@ -32,6 +32,11 @@ def setup_app(monkeypatch):
         "upload_file_and_get_url",
         lambda data, name, **k: f"https://blob/{name}",
     )
+    monkeypatch.setattr(
+        demo_module.blob,
+        "get_blob_url",
+        lambda name, **k: f"https://blob/{name}",
+    )
     called = {}
     import app.orchestrator as orch_module
     monkeypatch.setattr(
@@ -54,5 +59,5 @@ def test_load_demo(monkeypatch):
     body = resp.json()
     assert body["session_key"] == "sess"
     assert body["source"] == filename
-    assert body["source_url"].startswith("https://blob/sess/")
+    assert body["source_url"] == f"https://blob/demo/{filename}"
     assert called["prefix"] == "sess"


### PR DESCRIPTION
## Summary
- add helper to generate a SAS URL for existing blobs
- return demo PDF URL in `/load_demo`
- adjust demo API test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855826bd950832683f5b65fec90c2d5